### PR TITLE
chore: housekeeping for Champions pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ package-lock.json
 # Generated data
 /data/
 
+# Git worktrees
+.worktrees/
+
 # Local agent / workflow state
 .claire/
 .claude/council/sessions/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ package-lock.json
 
 # Generated data
 /data/
+
+# Local agent / workflow state
+.claire/
+.claude/council/sessions/
+memory/
+.npmrc

--- a/docs/superpowers/plans/2026-04-08-champions-pokedex-pipeline.md
+++ b/docs/superpowers/plans/2026-04-08-champions-pokedex-pipeline.md
@@ -1,0 +1,1684 @@
+# Champions Pokedex Data Pipeline — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Serebii-backed data pipeline that scrapes Champions Pokedex data (201 base Pokemon + 58 Mega forms) into separate SQLite tables, following the existing fetcher/store patterns.
+
+**Architecture:** New `fetcher/champions_dex.py` scrapes Serebii HTML pages using positional parsing, stores into `champions_dex_*` tables via transactional refresh. New `ChampionsDexPokemon` and `ChampionsDexMove` models in `database/models.py`. HTML parsing tested against saved fixtures.
+
+**Tech Stack:** Python 3.12, httpx (async HTTP), aiosqlite, BeautifulSoup4 (HTML parsing), pytest + pytest-asyncio
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/smogon_vgc_mcp/database/schema.py` | Modify | Add `champions_dex_*` table DDL |
+| `src/smogon_vgc_mcp/database/models.py` | Modify | Add `ChampionsDexPokemon`, `ChampionsDexMove` dataclasses |
+| `src/smogon_vgc_mcp/database/queries.py` | Modify | Add Champions Pokedex query functions |
+| `src/smogon_vgc_mcp/fetcher/champions_dex.py` | Create | Serebii scraper + store orchestrator |
+| `src/smogon_vgc_mcp/fetcher/champions_pokemon_list.py` | Create | Static list of 201 Champions Pokemon names |
+| `src/smogon_vgc_mcp/formats.py` | Modify | Uncomment `champions_ma` FormatConfig entry |
+| `tests/test_fetcher_champions_dex.py` | Create | HTML parsing tests with fixtures |
+| `tests/test_champions_dex_queries.py` | Create | Query function tests |
+| `tests/fixtures/` | Create dir | Saved Serebii HTML fixtures for parser tests |
+| `tests/fixtures/serebii_charizard.html` | Create | Sample Pokemon page fixture |
+| `tests/fixtures/serebii_charizard_mega_x.html` | Create | Sample Mega form page fixture |
+
+---
+
+### Task 1: Add BeautifulSoup4 dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Add bs4 to project dependencies**
+
+```toml
+# In [project.dependencies], add:
+"beautifulsoup4>=4.12",
+```
+
+- [ ] **Step 2: Install and verify**
+
+Run: `uv sync`
+Expected: Successful install, no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "chore: add beautifulsoup4 dependency for HTML parsing"
+```
+
+---
+
+### Task 2: Champions database schema — tables and indexes
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/database/schema.py`
+- Test: `tests/test_champions_dex_queries.py`
+
+- [ ] **Step 1: Write failing test that Champions tables exist after init**
+
+Create `tests/test_champions_dex_queries.py`:
+
+```python
+"""Tests for Champions Pokedex database schema and queries."""
+
+import pytest
+import aiosqlite
+
+from smogon_vgc_mcp.database.schema import init_database
+
+
+@pytest.mark.asyncio
+async def test_champions_tables_created(tmp_path):
+    """Champions dex tables should exist after database init."""
+    db_path = tmp_path / "test.db"
+    await init_database(db_path)
+
+    async with aiosqlite.connect(db_path) as db:
+        # Check champions_dex_pokemon exists
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='champions_dex_pokemon'"
+        ) as cursor:
+            row = await cursor.fetchone()
+            assert row is not None, "champions_dex_pokemon table not created"
+
+        # Check champions_dex_moves exists
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='champions_dex_moves'"
+        ) as cursor:
+            row = await cursor.fetchone()
+            assert row is not None, "champions_dex_moves table not created"
+
+        # Check champions_dex_abilities exists
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='champions_dex_abilities'"
+        ) as cursor:
+            row = await cursor.fetchone()
+            assert row is not None, "champions_dex_abilities table not created"
+
+        # Check champions_dex_learnsets exists
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='champions_dex_learnsets'"
+        ) as cursor:
+            row = await cursor.fetchone()
+            assert row is not None, "champions_dex_learnsets table not created"
+
+
+@pytest.mark.asyncio
+async def test_champions_pokemon_columns(tmp_path):
+    """champions_dex_pokemon should have Mega form columns."""
+    db_path = tmp_path / "test.db"
+    await init_database(db_path)
+
+    async with aiosqlite.connect(db_path) as db:
+        async with db.execute("PRAGMA table_info(champions_dex_pokemon)") as cursor:
+            columns = {row[1] async for row in cursor}
+
+        assert "base_form_id" in columns
+        assert "is_mega" in columns
+        assert "mega_stone" in columns
+        assert "hp" in columns
+        assert "type1" in columns
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_champions_dex_queries.py::test_champions_tables_created -v`
+Expected: FAIL — tables don't exist yet
+
+- [ ] **Step 3: Add Champions table DDL to SCHEMA**
+
+In `src/smogon_vgc_mcp/database/schema.py`, append to the `SCHEMA` string (before the closing `"""`):
+
+```sql
+-- =============================================================================
+-- Champions Pokedex data (from Serebii)
+-- =============================================================================
+
+-- Champions Pokemon species data (rebalanced stats, Mega forms)
+CREATE TABLE IF NOT EXISTS champions_dex_pokemon (
+    id TEXT PRIMARY KEY,
+    num INTEGER,
+    name TEXT NOT NULL,
+    type1 TEXT NOT NULL,
+    type2 TEXT,
+    hp INTEGER NOT NULL,
+    atk INTEGER NOT NULL,
+    def INTEGER NOT NULL,
+    spa INTEGER NOT NULL,
+    spd INTEGER NOT NULL,
+    spe INTEGER NOT NULL,
+    ability1 TEXT,
+    ability2 TEXT,
+    ability_hidden TEXT,
+    base_form_id TEXT,
+    is_mega INTEGER NOT NULL DEFAULT 0,
+    mega_stone TEXT,
+    height_m REAL,
+    weight_kg REAL
+);
+
+-- Champions move data (includes rebalanced moves)
+CREATE TABLE IF NOT EXISTS champions_dex_moves (
+    id TEXT PRIMARY KEY,
+    num INTEGER,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    category TEXT NOT NULL,
+    base_power INTEGER,
+    accuracy INTEGER,
+    pp INTEGER,
+    priority INTEGER DEFAULT 0,
+    target TEXT,
+    description TEXT,
+    short_desc TEXT
+);
+
+-- Champions ability data
+CREATE TABLE IF NOT EXISTS champions_dex_abilities (
+    id TEXT PRIMARY KEY,
+    num INTEGER,
+    name TEXT NOT NULL,
+    description TEXT,
+    short_desc TEXT
+);
+
+-- Champions learnsets (Pokemon -> Move mapping)
+CREATE TABLE IF NOT EXISTS champions_dex_learnsets (
+    pokemon_id TEXT,
+    move_id TEXT,
+    method TEXT,
+    PRIMARY KEY (pokemon_id, move_id)
+);
+
+-- Indexes for Champions Pokedex queries
+CREATE INDEX IF NOT EXISTS idx_champ_pokemon_name ON champions_dex_pokemon(name);
+CREATE INDEX IF NOT EXISTS idx_champ_pokemon_type1 ON champions_dex_pokemon(type1);
+CREATE INDEX IF NOT EXISTS idx_champ_pokemon_type2 ON champions_dex_pokemon(type2);
+CREATE INDEX IF NOT EXISTS idx_champ_pokemon_base_form ON champions_dex_pokemon(base_form_id);
+CREATE INDEX IF NOT EXISTS idx_champ_pokemon_is_mega ON champions_dex_pokemon(is_mega);
+CREATE INDEX IF NOT EXISTS idx_champ_moves_type ON champions_dex_moves(type);
+CREATE INDEX IF NOT EXISTS idx_champ_moves_category ON champions_dex_moves(category);
+CREATE INDEX IF NOT EXISTS idx_champ_abilities_name ON champions_dex_abilities(name);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_champions_dex_queries.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/database/schema.py tests/test_champions_dex_queries.py
+git commit -m "feat: add Champions Pokedex database tables and indexes (#6)"
+```
+
+---
+
+### Task 3: Champions data models
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/database/models.py`
+- Test: `tests/test_database_models.py`
+
+- [ ] **Step 1: Write failing test for ChampionsDexPokemon model**
+
+Append to `tests/test_database_models.py`:
+
+```python
+class TestChampionsDexPokemon:
+    """Tests for ChampionsDexPokemon dataclass."""
+
+    def test_base_form(self):
+        from smogon_vgc_mcp.database.models import ChampionsDexPokemon
+
+        pkmn = ChampionsDexPokemon(
+            id="charizard",
+            num=6,
+            name="Charizard",
+            types=["Fire", "Flying"],
+            base_stats={"hp": 78, "atk": 104, "def": 98, "spa": 159, "spd": 115, "spe": 100},
+            abilities=["Blaze"],
+        )
+        assert pkmn.name == "Charizard"
+        assert pkmn.base_stats["spa"] == 159
+        assert pkmn.is_mega is False
+        assert pkmn.base_form_id is None
+
+    def test_mega_form(self):
+        from smogon_vgc_mcp.database.models import ChampionsDexPokemon
+
+        mega = ChampionsDexPokemon(
+            id="charizard-mega-x",
+            num=6,
+            name="Mega Charizard X",
+            types=["Fire", "Dragon"],
+            base_stats={"hp": 78, "atk": 170, "def": 131, "spa": 170, "spd": 115, "spe": 100},
+            abilities=["Tough Claws"],
+            is_mega=True,
+            base_form_id="charizard",
+            mega_stone="Charizardite X",
+        )
+        assert mega.is_mega is True
+        assert mega.base_form_id == "charizard"
+        assert mega.mega_stone == "Charizardite X"
+
+
+class TestChampionsDexMove:
+    """Tests for ChampionsDexMove dataclass."""
+
+    def test_rebalanced_move(self):
+        from smogon_vgc_mcp.database.models import ChampionsDexMove
+
+        move = ChampionsDexMove(
+            id="flamethrower",
+            num=53,
+            name="Flamethrower",
+            type="Fire",
+            category="Special",
+            base_power=90,
+            accuracy=100,
+            pp=15,
+        )
+        assert move.base_power == 90
+        assert move.category == "Special"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_database_models.py::TestChampionsDexPokemon -v`
+Expected: FAIL — `ChampionsDexPokemon` does not exist
+
+- [ ] **Step 3: Add dataclasses to models.py**
+
+Append to `src/smogon_vgc_mcp/database/models.py`:
+
+```python
+# =============================================================================
+# Champions Pokedex data models (from Serebii)
+# =============================================================================
+
+
+@dataclass
+class ChampionsDexPokemon:
+    """Champions Pokemon species data (rebalanced stats, Mega forms)."""
+
+    id: str
+    num: int
+    name: str
+    types: list[str]
+    base_stats: dict[str, int]  # hp, atk, def, spa, spd, spe
+    abilities: list[str]
+    ability_hidden: str | None = None
+    height_m: float = 0.0
+    weight_kg: float = 0.0
+    is_mega: bool = False
+    base_form_id: str | None = None  # FK to base form for Megas
+    mega_stone: str | None = None
+
+
+@dataclass
+class ChampionsDexMove:
+    """Champions move data (includes rebalanced moves)."""
+
+    id: str
+    num: int
+    name: str
+    type: str
+    category: str
+    base_power: int | None
+    accuracy: int | None
+    pp: int
+    priority: int = 0
+    target: str | None = None
+    description: str | None = None
+    short_desc: str | None = None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_database_models.py::TestChampionsDexPokemon tests/test_database_models.py::TestChampionsDexMove -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/database/models.py tests/test_database_models.py
+git commit -m "feat: add ChampionsDexPokemon and ChampionsDexMove models (#6)"
+```
+
+---
+
+### Task 4: Champions Pokemon name list
+
+**Files:**
+- Create: `src/smogon_vgc_mcp/fetcher/champions_pokemon_list.py`
+- Test: `tests/test_fetcher_champions_dex.py`
+
+This is the static list of all 201 Champions Pokemon. The scraper iterates over this list to fetch individual Serebii pages. Serebii uses lowercased, hyphenated names in URLs (e.g., `/pokedex-champions/charizard/`).
+
+- [ ] **Step 1: Write failing test for the Pokemon list**
+
+Create `tests/test_fetcher_champions_dex.py`:
+
+```python
+"""Tests for Champions Pokedex fetcher."""
+
+
+class TestChampionsPokemonList:
+    """Tests for the static Champions Pokemon roster."""
+
+    def test_list_has_expected_count(self):
+        from smogon_vgc_mcp.fetcher.champions_pokemon_list import CHAMPIONS_POKEMON
+
+        # 201 base forms in the Champions roster
+        assert len(CHAMPIONS_POKEMON) == 201
+
+    def test_contains_key_pokemon(self):
+        from smogon_vgc_mcp.fetcher.champions_pokemon_list import CHAMPIONS_POKEMON
+
+        # Starters and iconic Pokemon must be present
+        for name in ["charizard", "pikachu", "mewtwo", "gardevoir", "dragonite", "greninja"]:
+            assert name in CHAMPIONS_POKEMON, f"{name} missing from Champions roster"
+
+    def test_names_are_lowercase(self):
+        from smogon_vgc_mcp.fetcher.champions_pokemon_list import CHAMPIONS_POKEMON
+
+        for name in CHAMPIONS_POKEMON:
+            assert name == name.lower(), f"{name} should be lowercase"
+            assert " " not in name, f"{name} should not contain spaces"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_fetcher_champions_dex.py::TestChampionsPokemonList -v`
+Expected: FAIL — module does not exist
+
+- [ ] **Step 3: Create the Pokemon list module**
+
+Create `src/smogon_vgc_mcp/fetcher/champions_pokemon_list.py`:
+
+```python
+"""Static list of all 201 Pokemon in Pokemon Champions.
+
+Used to drive the Serebii page scraper — each name maps to
+a Serebii URL at /pokedex-champions/{name}/.
+
+Source: Serebii.net Champions Pokedex (April 2026 launch roster).
+"""
+
+# fmt: off
+CHAMPIONS_POKEMON: list[str] = [
+    "venusaur", "charizard", "blastoise", "pikachu", "raichu",
+    "nidoqueen", "nidoking", "clefable", "ninetales", "arcanine",
+    "alakazam", "machamp", "golem", "gengar", "kingler",
+    "exeggutor", "marowak", "hitmonlee", "hitmonchan", "chansey",
+    "kangaskhan", "mr-mime", "scyther", "jynx", "pinsir",
+    "gyarados", "lapras", "ditto", "eevee", "vaporeon",
+    "jolteon", "flareon", "snorlax", "dragonite", "mewtwo",
+    "mew", "typhlosion", "feraligatr", "ampharos", "espeon",
+    "umbreon", "slowking", "steelix", "scizor", "heracross",
+    "kingdra", "hitmontop", "blissey", "tyranitar", "blaziken",
+    "swampert", "gardevoir", "breloom", "slaking", "sableye",
+    "mawile", "aggron", "medicham", "sharpedo", "camerupt",
+    "altaria", "zangoose", "seviper", "lunatone", "solrock",
+    "milotic", "banette", "absol", "salamence", "metagross",
+    "latias", "latios", "rayquaza", "jirachi", "infernape",
+    "empoleon", "luxray", "roserade", "garchomp", "lucario",
+    "hippowdon", "drapion", "toxicroak", "leafeon", "glaceon",
+    "gallade", "dusknoir", "rotom", "darkrai", "arceus",
+    "samurott", "excadrill", "audino", "conkeldurr", "scolipede",
+    "krookodile", "darmanitan", "zoroark", "reuniclus", "chandelure",
+    "haxorus", "mienshao", "hydreigon", "volcarona", "greninja",
+    "talonflame", "vivillon", "aegislash", "sylveon", "goodra",
+    "trevenant", "noivern", "decidueye", "incineroar", "primarina",
+    "lycanroc", "toxapex", "mudsdale", "araquanid", "lurantis",
+    "bewear", "tsareena", "comfey", "mimikyu", "kommo-o",
+    "cinderace", "rillaboom", "inteleon", "corviknight", "orbeetle",
+    "drednaw", "coalossal", "appletun", "sandaconda", "cramorant",
+    "barraskewda", "toxtricity", "centiskorch", "polteageist",
+    "hatterene", "grimmsnarl", "obstagoon", "perrserker", "cursola",
+    "sirfetchd", "mr-rime", "runerigus", "alcremie", "falinks",
+    "pincurchin", "frosmoth", "stonjourner", "eiscue", "copperajah",
+    "dracozolt", "arctozolt", "dracovish", "arctovish", "duraludon",
+    "dragapult", "urshifu", "zarude", "glastrier", "spectrier",
+    "wyrdeer", "kleavor", "ursaluna", "basculegion", "sneasler",
+    "overqwil", "enamorus", "meowscarada", "skeledirge", "quaquaval",
+    "spidops", "lokix", "pawmot", "maushold", "dachsbun",
+    "arboliva", "squawkabilly", "nacli", "garganacl", "armarouge",
+    "ceruledge", "palafin", "flamigo", "cetitan", "veluza",
+    "dondozo", "tatsugiri", "annihilape", "clodsire", "farigiraf",
+    "dudunsparce", "kingambit", "great-tusk", "iron-treads",
+    "iron-hands", "iron-jugulis", "iron-thorns", "iron-bundle",
+    "iron-valiant", "roaring-moon", "iron-leaves", "bloodmoon-ursaluna",
+    "ogerpon", "terapagos",
+]
+# fmt: on
+
+# Mega forms are discovered during scraping — the base form page links to them.
+# This dict maps base_form_id -> list of (mega_id, mega_stone) tuples.
+# Populated at scrape time, but known Megas listed here for reference/validation.
+KNOWN_MEGA_POKEMON: dict[str, list[tuple[str, str]]] = {
+    "charizard": [("charizard-mega-x", "Charizardite X"), ("charizard-mega-y", "Charizardite Y")],
+    "mewtwo": [("mewtwo-mega-x", "Mewtwonite X"), ("mewtwo-mega-y", "Mewtwonite Y")],
+    "venusaur": [("venusaur-mega", "Venusaurite")],
+    "blastoise": [("blastoise-mega", "Blastoisinite")],
+    "alakazam": [("alakazam-mega", "Alakazite")],
+    "gengar": [("gengar-mega", "Gengarite")],
+    "kangaskhan": [("kangaskhan-mega", "Kangaskhanite")],
+    "pinsir": [("pinsir-mega", "Pinsirite")],
+    "gyarados": [("gyarados-mega", "Gyaradosite")],
+    "scizor": [("scizor-mega", "Scizorite")],
+    "heracross": [("heracross-mega", "Heracrossite")],
+    "tyranitar": [("tyranitar-mega", "Tyranitarite")],
+    "blaziken": [("blaziken-mega", "Blazikenite")],
+    "swampert": [("swampert-mega", "Swampertite")],
+    "gardevoir": [("gardevoir-mega", "Gardevoirite")],
+    "mawile": [("mawile-mega", "Mawilite")],
+    "aggron": [("aggron-mega", "Aggronite")],
+    "medicham": [("medicham-mega", "Medichamite")],
+    "sharpedo": [("sharpedo-mega", "Sharpedonite")],
+    "camerupt": [("camerupt-mega", "Cameruptite")],
+    "altaria": [("altaria-mega", "Altarianite")],
+    "banette": [("banette-mega", "Banettite")],
+    "absol": [("absol-mega", "Absolite")],
+    "salamence": [("salamence-mega", "Salamencite")],
+    "metagross": [("metagross-mega", "Metagrossite")],
+    "latias": [("latias-mega", "Latiasite")],
+    "latios": [("latios-mega", "Latiosite")],
+    "rayquaza": [("rayquaza-mega", "N/A")],
+    "garchomp": [("garchomp-mega", "Garchompite")],
+    "lucario": [("lucario-mega", "Lucarionite")],
+    "gallade": [("gallade-mega", "Galladite")],
+    "audino": [("audino-mega", "Audinite")],
+    "diancie": [("diancie-mega", "Diancite")],
+    "sableye": [("sableye-mega", "Sablenite")],
+    # Champions-exclusive new Megas:
+    "dragonite": [("dragonite-mega", "Dragonitite")],
+    "greninja": [("greninja-mega", "Greninjaite")],
+    "clefable": [("clefable-mega", "Clefablite")],
+    "arcanine": [("arcanine-mega", "Arcaninite")],
+    "machamp": [("machamp-mega", "Machampite")],
+    "snorlax": [("snorlax-mega", "Snorlaxite")],
+    "kingdra": [("kingdra-mega", "Kingdranite")],
+    "milotic": [("milotic-mega", "Milotite")],
+    "infernape": [("infernape-mega", "Infernapite")],
+    "darkrai": [("darkrai-mega", "Darkrainite")],
+    "volcarona": [("volcarona-mega", "Volcaronite")],
+    "hydreigon": [("hydreigon-mega", "Hydreigonite")],
+    "aegislash": [("aegislash-mega", "Aegislashite")],
+    "goodra": [("goodra-mega", "Goodranite")],
+    "mimikyu": [("mimikyu-mega", "Mimikyunite")],
+    "dragapult": [("dragapult-mega", "Dragapultite")],
+    "hatterene": [("hatterene-mega", "Hatterenite")],
+    "grimmsnarl": [("grimmsnarl-mega", "Grimmsnarlite")],
+    "toxtricity": [("toxtricity-mega", "Toxtricitite")],
+    "kommo-o": [("kommo-o-mega", "Kommonite")],
+    "annihilape": [("annihilape-mega", "Annihilapite")],
+    "kingambit": [("kingambit-mega", "Kingambitite")],
+    "incineroar": [("incineroar-mega", "Incineroarenite")],
+}
+```
+
+> **Note:** This list will need validation against the actual Serebii roster page. The exact 201 names and 58 Mega forms should be verified during a dry-run scrape (Task 7). Some names/stones are best-effort from research and may need correction.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_fetcher_champions_dex.py::TestChampionsPokemonList -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/champions_pokemon_list.py tests/test_fetcher_champions_dex.py
+git commit -m "feat: add Champions Pokemon roster list (201 base forms + known Megas) (#6)"
+```
+
+---
+
+### Task 5: Serebii HTML parser — Pokemon page
+
+**Files:**
+- Create: `tests/fixtures/` directory
+- Create: `tests/fixtures/serebii_charizard.html` (saved fixture)
+- Create: `tests/fixtures/serebii_charizard_mega_x.html` (saved fixture)
+- Create: `src/smogon_vgc_mcp/fetcher/champions_dex.py`
+- Modify: `tests/test_fetcher_champions_dex.py`
+
+The parser extracts from Serebii's `/pokedex-champions/{name}/` pages: name, types, base stats (HP/Atk/Def/SpA/SpD/Spe), abilities, height, weight, and Mega form links. Serebii HTML has **no CSS class names** on data cells — parse by table structure and text patterns.
+
+- [ ] **Step 1: Fetch and save HTML fixtures**
+
+Run these manually to create test fixtures (do NOT commit to automated scraping without fixtures):
+
+```bash
+mkdir -p tests/fixtures
+curl -s "https://www.serebii.net/pokedex-champions/charizard/" -o tests/fixtures/serebii_charizard.html
+curl -s "https://www.serebii.net/pokedex-champions/mewtwo/" -o tests/fixtures/serebii_mewtwo.html
+```
+
+If Serebii returns 403, use a browser User-Agent:
+```bash
+curl -s -H "User-Agent: Mozilla/5.0" "https://www.serebii.net/pokedex-champions/charizard/" -o tests/fixtures/serebii_charizard.html
+```
+
+Inspect the HTML structure to identify:
+- The table containing base stats (look for "HP", "Attack", "Defense" header cells)
+- The table/section containing type information
+- The table/section containing abilities
+- Links to Mega Evolution pages (if present on base form page)
+
+> **IMPORTANT:** Before writing the parser, you MUST read the actual downloaded HTML and adapt the parsing logic to match the real structure. The code below is a template based on typical Serebii layout — adjust selectors after inspecting fixtures.
+
+- [ ] **Step 2: Write failing tests for the parser**
+
+Add to `tests/test_fetcher_champions_dex.py`:
+
+```python
+from pathlib import Path
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class TestParseSerebiiPokemonPage:
+    """Tests for parsing Serebii Champions Pokemon pages."""
+
+    def test_parse_base_form_stats(self):
+        from smogon_vgc_mcp.fetcher.champions_dex import parse_serebii_pokemon_page
+
+        html = (FIXTURES_DIR / "serebii_charizard.html").read_text()
+        result = parse_serebii_pokemon_page(html, "charizard")
+
+        assert result is not None
+        assert result["name"] == "Charizard"
+        assert "Fire" in result["types"]
+        assert len(result["base_stats"]) == 6
+        assert all(stat in result["base_stats"] for stat in ["hp", "atk", "def", "spa", "spd", "spe"])
+        # Champions Charizard has rebalanced stats (SpA 159, not 109)
+        assert result["base_stats"]["spa"] > 100
+        assert len(result["abilities"]) >= 1
+
+    def test_parse_detects_mega_forms(self):
+        from smogon_vgc_mcp.fetcher.champions_dex import parse_serebii_pokemon_page
+
+        html = (FIXTURES_DIR / "serebii_charizard.html").read_text()
+        result = parse_serebii_pokemon_page(html, "charizard")
+
+        assert result is not None
+        # Charizard has Mega X and Mega Y
+        assert len(result.get("mega_forms", [])) >= 1
+
+    def test_parse_returns_none_for_empty_html(self):
+        from smogon_vgc_mcp.fetcher.champions_dex import parse_serebii_pokemon_page
+
+        result = parse_serebii_pokemon_page("", "charizard")
+        assert result is None
+
+    def test_parse_returns_none_for_404_page(self):
+        from smogon_vgc_mcp.fetcher.champions_dex import parse_serebii_pokemon_page
+
+        result = parse_serebii_pokemon_page("<html><body>404 Not Found</body></html>", "fakemon")
+        assert result is None
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_fetcher_champions_dex.py::TestParseSerebiiPokemonPage -v`
+Expected: FAIL — `parse_serebii_pokemon_page` does not exist
+
+- [ ] **Step 4: Implement the parser**
+
+Create `src/smogon_vgc_mcp/fetcher/champions_dex.py`:
+
+```python
+"""Fetch and parse Champions Pokedex data from Serebii.
+
+Serebii HTML has no CSS class names on data cells. Parsing relies on
+table structure and text patterns. All parsing logic is tested against
+saved HTML fixtures to catch breakage from layout changes.
+
+Data source: serebii.net/pokedex-champions/
+Attribution: Pokemon data from Serebii.net.
+"""
+
+import asyncio
+import re
+
+from bs4 import BeautifulSoup, Tag
+
+from smogon_vgc_mcp.utils import fetch_text_resilient
+
+SEREBII_BASE_URL = "https://www.serebii.net/pokedex-champions"
+SEREBII_SERVICE = "serebii"
+# Polite delay between requests (seconds)
+REQUEST_DELAY = 1.0
+
+
+def parse_serebii_pokemon_page(html: str, pokemon_id: str) -> dict | None:
+    """Parse a Serebii Champions Pokemon page into structured data.
+
+    Args:
+        html: Raw HTML content from serebii.net/pokedex-champions/{name}/
+        pokemon_id: Lowercase Pokemon identifier (e.g., "charizard")
+
+    Returns:
+        Dict with keys: name, types, base_stats, abilities, ability_hidden,
+        height_m, weight_kg, mega_forms. Returns None if parsing fails.
+    """
+    if not html or len(html) < 100:
+        return None
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Detect 404/error pages
+    title = soup.find("title")
+    if title and "404" in title.get_text():
+        return None
+
+    result: dict = {
+        "pokemon_id": pokemon_id,
+        "name": "",
+        "types": [],
+        "base_stats": {},
+        "abilities": [],
+        "ability_hidden": None,
+        "height_m": 0.0,
+        "weight_kg": 0.0,
+        "mega_forms": [],
+    }
+
+    # --- Parse name ---
+    # Serebii typically has the Pokemon name in a large header or title
+    name = _extract_name(soup, pokemon_id)
+    if not name:
+        return None
+    result["name"] = name
+
+    # --- Parse types ---
+    result["types"] = _extract_types(soup)
+
+    # --- Parse base stats ---
+    result["base_stats"] = _extract_base_stats(soup)
+    if not result["base_stats"]:
+        return None
+
+    # --- Parse abilities ---
+    abilities, hidden = _extract_abilities(soup)
+    result["abilities"] = abilities
+    result["ability_hidden"] = hidden
+
+    # --- Parse physical data ---
+    result["height_m"], result["weight_kg"] = _extract_physical_data(soup)
+
+    # --- Detect Mega forms ---
+    result["mega_forms"] = _extract_mega_links(soup, pokemon_id)
+
+    return result
+
+
+def _extract_name(soup: BeautifulSoup, pokemon_id: str) -> str:
+    """Extract Pokemon name from page. Adapt after inspecting fixture HTML."""
+    # Strategy 1: Look for the main header with Pokemon name
+    # Serebii often uses a table cell with the name prominently
+    for td in soup.find_all("td"):
+        text = td.get_text(strip=True)
+        # Match pattern like "Charizard" or "#006 Charizard"
+        if pokemon_id.replace("-", "").lower() in text.replace(" ", "").lower():
+            # Extract just the name part
+            name_match = re.search(r"#?\d*\s*([A-Z][a-zA-Z\s\-':.]+)", text)
+            if name_match:
+                return name_match.group(1).strip()
+
+    # Fallback: title tag
+    title = soup.find("title")
+    if title:
+        title_text = title.get_text()
+        # Serebii titles are like "Charizard - Pokemon Champions Pokedex"
+        name_match = re.match(r"([^-]+)", title_text)
+        if name_match:
+            return name_match.group(1).strip()
+
+    return pokemon_id.replace("-", " ").title()
+
+
+def _extract_types(soup: BeautifulSoup) -> list[str]:
+    """Extract Pokemon types from page.
+
+    Serebii shows types as small images with alt text like 'Fire' or 'Flying'.
+    Look for img tags with src containing '/type/' or alt matching known types.
+    """
+    known_types = {
+        "Normal", "Fire", "Water", "Electric", "Grass", "Ice",
+        "Fighting", "Poison", "Ground", "Flying", "Psychic", "Bug",
+        "Rock", "Ghost", "Dragon", "Dark", "Steel", "Fairy",
+    }
+    types: list[str] = []
+
+    # Look for type images — Serebii uses /type/fire.gif etc.
+    for img in soup.find_all("img"):
+        src = img.get("src", "")
+        alt = img.get("alt", "")
+        if "/type/" in src.lower():
+            # Extract type name from src: /type/fire.gif -> Fire
+            type_match = re.search(r"/type/(\w+)\.", src, re.IGNORECASE)
+            if type_match:
+                type_name = type_match.group(1).capitalize()
+                if type_name in known_types and type_name not in types:
+                    types.append(type_name)
+        elif alt in known_types and alt not in types:
+            types.append(alt)
+
+    # Deduplicate while preserving order, take first two
+    return types[:2]
+
+
+def _extract_base_stats(soup: BeautifulSoup) -> dict[str, int]:
+    """Extract base stats from the stats table.
+
+    Looks for a table containing cells with text 'HP', 'Attack', 'Defense',
+    'Sp. Attack', 'Sp. Defense', 'Speed' followed by numeric values.
+    """
+    stat_names = {
+        "HP": "hp",
+        "Attack": "atk",
+        "Defense": "def",
+        "Sp. Attack": "spa",
+        "Sp. Atk": "spa",
+        "Sp. Defense": "spd",
+        "Sp. Def": "spd",
+        "Speed": "spe",
+    }
+    stats: dict[str, int] = {}
+
+    # Find all tables and look for one containing stat headers
+    for table in soup.find_all("table"):
+        table_text = table.get_text()
+        if "HP" in table_text and "Attack" in table_text and "Speed" in table_text:
+            rows = table.find_all("tr")
+            for row in rows:
+                cells = row.find_all(["td", "th"])
+                for i, cell in enumerate(cells):
+                    cell_text = cell.get_text(strip=True)
+                    if cell_text in stat_names:
+                        key = stat_names[cell_text]
+                        # Look for the numeric value in the next cell
+                        if i + 1 < len(cells):
+                            val_text = cells[i + 1].get_text(strip=True)
+                            val_match = re.search(r"(\d+)", val_text)
+                            if val_match and key not in stats:
+                                stats[key] = int(val_match.group(1))
+
+            if len(stats) == 6:
+                return stats
+
+    # Fallback: search for stat pattern in any context
+    # Some Serebii pages use a different layout
+    all_text = soup.get_text()
+    for display_name, key in stat_names.items():
+        if key not in stats:
+            pattern = rf"{re.escape(display_name)}\s*[:：]?\s*(\d+)"
+            match = re.search(pattern, all_text)
+            if match:
+                stats[key] = int(match.group(1))
+
+    return stats if len(stats) == 6 else {}
+
+
+def _extract_abilities(soup: BeautifulSoup) -> tuple[list[str], str | None]:
+    """Extract abilities from page. Returns (regular_abilities, hidden_ability)."""
+    abilities: list[str] = []
+    hidden: str | None = None
+
+    # Serebii shows abilities in a section — look for "Abilities" header
+    for td in soup.find_all("td"):
+        text = td.get_text(strip=True)
+        if "Abilities:" in text or "Ability:" in text:
+            # Extract ability names from links within parent context
+            parent = td.parent
+            if parent:
+                for a_tag in parent.find_all("a"):
+                    ability_name = a_tag.get_text(strip=True)
+                    if ability_name and len(ability_name) > 1:
+                        abilities.append(ability_name)
+
+    # Look for hidden ability marker
+    for td in soup.find_all("td"):
+        text = td.get_text(strip=True)
+        if "Hidden Ability" in text or "Hidden:" in text:
+            parent = td.parent
+            if parent:
+                for a_tag in parent.find_all("a"):
+                    ability_name = a_tag.get_text(strip=True)
+                    if ability_name and len(ability_name) > 1:
+                        hidden = ability_name
+                        break
+
+    return abilities, hidden
+
+
+def _extract_physical_data(soup: BeautifulSoup) -> tuple[float, float]:
+    """Extract height (m) and weight (kg) from page."""
+    height = 0.0
+    weight = 0.0
+    all_text = soup.get_text()
+
+    height_match = re.search(r"Height\s*[:：]?\s*([\d.]+)\s*m", all_text)
+    if height_match:
+        height = float(height_match.group(1))
+
+    weight_match = re.search(r"Weight\s*[:：]?\s*([\d.]+)\s*kg", all_text)
+    if weight_match:
+        weight = float(weight_match.group(1))
+
+    return height, weight
+
+
+def _extract_mega_links(soup: BeautifulSoup, pokemon_id: str) -> list[dict]:
+    """Extract links to Mega Evolution pages from the base form page.
+
+    Returns list of dicts: [{"id": "charizard-mega-x", "name": "Mega Charizard X", "url": "..."}]
+    """
+    megas: list[dict] = []
+
+    for a_tag in soup.find_all("a", href=True):
+        href = a_tag.get("href", "")
+        text = a_tag.get_text(strip=True)
+        # Look for links containing "mega" in the Pokemon context
+        if "mega" in href.lower() and pokemon_id.replace("-", "") in href.lower().replace("-", ""):
+            mega_id = href.strip("/").split("/")[-1] if "/" in href else href
+            megas.append({
+                "id": mega_id,
+                "name": text or f"Mega {pokemon_id.title()}",
+                "url": href,
+            })
+
+    return megas
+```
+
+- [ ] **Step 5: Run tests (some may need fixture adjustment)**
+
+Run: `uv run pytest tests/test_fetcher_champions_dex.py::TestParseSerebiiPokemonPage -v`
+
+If tests fail because the HTML structure doesn't match expectations, **read the fixture HTML** and adjust the parser functions. This is expected — the parser template above is best-effort and must be adapted to actual Serebii markup.
+
+- [ ] **Step 6: Iterate until all parser tests pass**
+
+Adjust `_extract_*` functions based on actual fixture HTML structure. Common fixes:
+- Serebii may use `<th>` instead of `<td>` for stat headers
+- Type images may be in a different parent element
+- Abilities may be rendered differently than expected
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/champions_dex.py tests/test_fetcher_champions_dex.py tests/fixtures/
+git commit -m "feat: add Serebii HTML parser for Champions Pokemon pages (#6)"
+```
+
+---
+
+### Task 6: Store functions — Champions Pokemon and moves to SQLite
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/fetcher/champions_dex.py`
+- Modify: `tests/test_champions_dex_queries.py`
+
+- [ ] **Step 1: Write failing test for store_champions_pokemon**
+
+Add to `tests/test_champions_dex_queries.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_store_champions_pokemon(tmp_path):
+    """Store and retrieve a Champions Pokemon."""
+    db_path = tmp_path / "test.db"
+    await init_database(db_path)
+
+    from smogon_vgc_mcp.fetcher.champions_dex import store_champions_pokemon_data
+
+    pokemon_data = [
+        {
+            "pokemon_id": "charizard",
+            "num": 6,
+            "name": "Charizard",
+            "types": ["Fire", "Flying"],
+            "base_stats": {"hp": 78, "atk": 104, "def": 98, "spa": 159, "spd": 115, "spe": 100},
+            "abilities": ["Blaze"],
+            "ability_hidden": "Solar Power",
+            "height_m": 1.7,
+            "weight_kg": 90.5,
+            "is_mega": False,
+            "base_form_id": None,
+            "mega_stone": None,
+        },
+        {
+            "pokemon_id": "charizard-mega-x",
+            "num": 6,
+            "name": "Mega Charizard X",
+            "types": ["Fire", "Dragon"],
+            "base_stats": {"hp": 78, "atk": 170, "def": 131, "spa": 170, "spd": 115, "spe": 100},
+            "abilities": ["Tough Claws"],
+            "ability_hidden": None,
+            "height_m": 1.7,
+            "weight_kg": 110.5,
+            "is_mega": True,
+            "base_form_id": "charizard",
+            "mega_stone": "Charizardite X",
+        },
+    ]
+
+    async with aiosqlite.connect(db_path) as db:
+        count = await store_champions_pokemon_data(db, pokemon_data)
+        assert count == 2
+
+        # Verify stored data
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT * FROM champions_dex_pokemon WHERE id = ?", ("charizard",)
+        ) as cursor:
+            row = await cursor.fetchone()
+            assert row is not None
+            assert row["name"] == "Charizard"
+            assert row["type1"] == "Fire"
+            assert row["type2"] == "Flying"
+            assert row["spa"] == 159
+            assert row["is_mega"] == 0
+
+        async with db.execute(
+            "SELECT * FROM champions_dex_pokemon WHERE id = ?", ("charizard-mega-x",)
+        ) as cursor:
+            row = await cursor.fetchone()
+            assert row is not None
+            assert row["is_mega"] == 1
+            assert row["base_form_id"] == "charizard"
+            assert row["mega_stone"] == "Charizardite X"
+
+
+@pytest.mark.asyncio
+async def test_store_champions_pokemon_transactional(tmp_path):
+    """Store is atomic — partial failures leave no data."""
+    db_path = tmp_path / "test.db"
+    await init_database(db_path)
+
+    from smogon_vgc_mcp.fetcher.champions_dex import store_champions_pokemon_data
+
+    # First store some valid data
+    valid_data = [{
+        "pokemon_id": "pikachu",
+        "num": 25,
+        "name": "Pikachu",
+        "types": ["Electric"],
+        "base_stats": {"hp": 55, "atk": 80, "def": 50, "spa": 75, "spd": 60, "spe": 110},
+        "abilities": ["Static"],
+        "ability_hidden": "Lightning Rod",
+        "height_m": 0.4,
+        "weight_kg": 6.0,
+        "is_mega": False,
+        "base_form_id": None,
+        "mega_stone": None,
+    }]
+
+    async with aiosqlite.connect(db_path) as db:
+        await store_champions_pokemon_data(db, valid_data)
+        await db.commit()
+
+    # Verify Pikachu exists
+    async with aiosqlite.connect(db_path) as db:
+        async with db.execute("SELECT COUNT(*) FROM champions_dex_pokemon") as cursor:
+            count = (await cursor.fetchone())[0]
+            assert count == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_champions_dex_queries.py::test_store_champions_pokemon -v`
+Expected: FAIL — `store_champions_pokemon_data` does not exist
+
+- [ ] **Step 3: Implement store functions**
+
+Add to `src/smogon_vgc_mcp/fetcher/champions_dex.py`:
+
+```python
+import aiosqlite
+
+
+async def store_champions_pokemon_data(
+    db: aiosqlite.Connection,
+    pokemon_list: list[dict],
+    *,
+    _commit: bool = True,
+) -> int:
+    """Store Champions Pokemon data into champions_dex_pokemon table.
+
+    Follows the same transactional pattern as pokedex.py — caller
+    controls commit via _commit flag for atomic batch operations.
+
+    Args:
+        db: Database connection
+        pokemon_list: List of parsed Pokemon dicts from parse_serebii_pokemon_page
+        _commit: Whether to commit after storing (False for batch transactions)
+
+    Returns:
+        Number of Pokemon stored
+    """
+    await db.execute("DELETE FROM champions_dex_pokemon")
+
+    count = 0
+    for pkmn in pokemon_list:
+        types = pkmn.get("types", [])
+        stats = pkmn.get("base_stats", {})
+
+        await db.execute(
+            """INSERT OR REPLACE INTO champions_dex_pokemon
+               (id, num, name, type1, type2,
+                hp, atk, def, spa, spd, spe,
+                ability1, ability2, ability_hidden,
+                base_form_id, is_mega, mega_stone,
+                height_m, weight_kg)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                pkmn["pokemon_id"],
+                pkmn.get("num"),
+                pkmn["name"],
+                types[0] if types else None,
+                types[1] if len(types) > 1 else None,
+                stats.get("hp"),
+                stats.get("atk"),
+                stats.get("def"),
+                stats.get("spa"),
+                stats.get("spd"),
+                stats.get("spe"),
+                pkmn["abilities"][0] if pkmn.get("abilities") else None,
+                pkmn["abilities"][1] if len(pkmn.get("abilities", [])) > 1 else None,
+                pkmn.get("ability_hidden"),
+                pkmn.get("base_form_id"),
+                1 if pkmn.get("is_mega") else 0,
+                pkmn.get("mega_stone"),
+                pkmn.get("height_m", 0.0),
+                pkmn.get("weight_kg", 0.0),
+            ),
+        )
+        count += 1
+
+    if _commit:
+        await db.commit()
+    return count
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_champions_dex_queries.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/champions_dex.py tests/test_champions_dex_queries.py
+git commit -m "feat: add store function for Champions Pokemon data (#6)"
+```
+
+---
+
+### Task 7: Fetch orchestrator — scrape all Champions Pokemon from Serebii
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/fetcher/champions_dex.py`
+- Modify: `tests/test_fetcher_champions_dex.py`
+
+- [ ] **Step 1: Write failing test for the orchestrator**
+
+Add to `tests/test_fetcher_champions_dex.py`:
+
+```python
+from unittest.mock import AsyncMock, patch
+
+
+class TestFetchChampionsDex:
+    """Tests for the fetch orchestrator."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_single_pokemon(self):
+        """Test fetching a single Pokemon page."""
+        from smogon_vgc_mcp.fetcher.champions_dex import fetch_champions_pokemon_page
+        from smogon_vgc_mcp.resilience import FetchResult
+
+        # Mock the HTTP fetch to return fixture HTML
+        fixture_html = (FIXTURES_DIR / "serebii_charizard.html").read_text()
+        mock_result = FetchResult.ok(fixture_html)
+
+        with patch(
+            "smogon_vgc_mcp.fetcher.champions_dex.fetch_text_resilient",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            result = await fetch_champions_pokemon_page("charizard")
+
+        assert result is not None
+        assert result["name"] == "Charizard"
+
+    @pytest.mark.asyncio
+    async def test_dry_run_validates_parsing(self):
+        """Dry run should validate parsing on a small subset before full scrape."""
+        from smogon_vgc_mcp.fetcher.champions_dex import fetch_and_store_champions_dex
+        from smogon_vgc_mcp.resilience import FetchResult
+
+        fixture_html = (FIXTURES_DIR / "serebii_charizard.html").read_text()
+        mock_result = FetchResult.ok(fixture_html)
+
+        with patch(
+            "smogon_vgc_mcp.fetcher.champions_dex.fetch_text_resilient",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            result = await fetch_and_store_champions_dex(
+                dry_run=True,
+                dry_run_names=["charizard"],
+            )
+
+        assert result["dry_run"] is True
+        assert result["pokemon_parsed"] >= 1
+        assert result["errors"] is None or len(result["errors"]) == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_fetcher_champions_dex.py::TestFetchChampionsDex -v`
+Expected: FAIL — functions don't exist
+
+- [ ] **Step 3: Implement fetch orchestrator**
+
+Add to `src/smogon_vgc_mcp/fetcher/champions_dex.py`:
+
+```python
+from pathlib import Path
+
+from smogon_vgc_mcp.database.schema import get_connection, get_db_path, init_database
+from smogon_vgc_mcp.fetcher.champions_pokemon_list import CHAMPIONS_POKEMON
+from smogon_vgc_mcp.resilience import FetchResult, get_all_circuit_states
+
+
+async def fetch_champions_pokemon_page(pokemon_id: str) -> dict | None:
+    """Fetch and parse a single Champions Pokemon page from Serebii.
+
+    Args:
+        pokemon_id: Lowercase Pokemon identifier (e.g., "charizard")
+
+    Returns:
+        Parsed Pokemon dict, or None if fetch/parse failed
+    """
+    url = f"{SEREBII_BASE_URL}/{pokemon_id}/"
+    result: FetchResult[str] = await fetch_text_resilient(url, service=SEREBII_SERVICE)
+
+    if not result.success or not result.data:
+        return None
+
+    return parse_serebii_pokemon_page(result.data, pokemon_id)
+
+
+async def fetch_and_store_champions_dex(
+    db_path: Path | None = None,
+    *,
+    dry_run: bool = False,
+    dry_run_names: list[str] | None = None,
+    request_delay: float = REQUEST_DELAY,
+) -> dict:
+    """Fetch and store all Champions Pokedex data from Serebii.
+
+    Follows the same two-phase pattern as pokedex.py:
+    Phase 1 — Fetch all pages into memory (no DB writes)
+    Phase 2 — Store atomically in a single transaction
+
+    Args:
+        db_path: Database file path (defaults to project data dir)
+        dry_run: If True, parse a small subset and report results without storing
+        dry_run_names: Pokemon to parse in dry_run mode (default: first 5)
+        request_delay: Seconds to wait between HTTP requests (polite crawling)
+
+    Returns:
+        Dict with pokemon_parsed, pokemon_stored, mega_forms_found, errors, etc.
+    """
+    if db_path is None:
+        db_path = get_db_path()
+
+    names = dry_run_names or CHAMPIONS_POKEMON[:5] if dry_run else CHAMPIONS_POKEMON
+    errors: list[dict] = []
+    all_pokemon: list[dict] = []
+
+    # Phase 1: Fetch all pages into memory
+    for i, name in enumerate(names):
+        if i > 0:
+            await asyncio.sleep(request_delay)
+
+        print(f"  [{i + 1}/{len(names)}] Fetching {name}...")
+        parsed = await fetch_champions_pokemon_page(name)
+
+        if parsed is None:
+            errors.append({"pokemon": name, "error": "Failed to fetch or parse"})
+            continue
+
+        parsed["is_mega"] = False
+        parsed["base_form_id"] = None
+        parsed["mega_stone"] = None
+        all_pokemon.append(parsed)
+
+        # Fetch Mega forms if detected
+        for mega in parsed.get("mega_forms", []):
+            mega_id = mega["id"]
+            await asyncio.sleep(request_delay)
+            print(f"    Fetching Mega form: {mega_id}...")
+            mega_parsed = await fetch_champions_pokemon_page(mega_id)
+            if mega_parsed:
+                mega_parsed["is_mega"] = True
+                mega_parsed["base_form_id"] = name
+                mega_parsed["mega_stone"] = mega.get("stone", None)
+                all_pokemon.append(mega_parsed)
+            else:
+                errors.append({"pokemon": mega_id, "error": "Failed to fetch Mega form"})
+
+    if dry_run:
+        return {
+            "dry_run": True,
+            "pokemon_parsed": len(all_pokemon),
+            "errors": errors if errors else None,
+            "parsed_names": [p["name"] for p in all_pokemon],
+            "circuit_states": get_all_circuit_states(),
+        }
+
+    # Phase 2: Store atomically
+    await init_database(db_path)
+    pokemon_count = 0
+
+    async with get_connection(db_path) as db:
+        try:
+            pokemon_count = await store_champions_pokemon_data(
+                db, all_pokemon, _commit=False
+            )
+            await db.commit()
+            print(f"  Stored {pokemon_count} Champions Pokemon")
+        except Exception:
+            await db.rollback()
+            raise
+
+    return {
+        "dry_run": False,
+        "pokemon_parsed": len(all_pokemon),
+        "pokemon_stored": pokemon_count,
+        "mega_forms_found": sum(1 for p in all_pokemon if p.get("is_mega")),
+        "errors": errors if errors else None,
+        "circuit_states": get_all_circuit_states(),
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_fetcher_champions_dex.py::TestFetchChampionsDex -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/champions_dex.py tests/test_fetcher_champions_dex.py
+git commit -m "feat: add Champions Pokedex fetch orchestrator with dry-run mode (#6)"
+```
+
+---
+
+### Task 8: Champions Pokedex query functions
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/database/queries.py`
+- Modify: `tests/test_champions_dex_queries.py`
+
+- [ ] **Step 1: Write failing tests for query functions**
+
+Add to `tests/test_champions_dex_queries.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_get_champions_pokemon(tmp_path):
+    """Query a Champions Pokemon by ID."""
+    db_path = tmp_path / "test.db"
+    await init_database(db_path)
+
+    from smogon_vgc_mcp.fetcher.champions_dex import store_champions_pokemon_data
+    from smogon_vgc_mcp.database.queries import get_champions_pokemon
+
+    pokemon_data = [{
+        "pokemon_id": "charizard",
+        "num": 6,
+        "name": "Charizard",
+        "types": ["Fire", "Flying"],
+        "base_stats": {"hp": 78, "atk": 104, "def": 98, "spa": 159, "spd": 115, "spe": 100},
+        "abilities": ["Blaze"],
+        "ability_hidden": "Solar Power",
+        "height_m": 1.7,
+        "weight_kg": 90.5,
+        "is_mega": False,
+        "base_form_id": None,
+        "mega_stone": None,
+    }]
+
+    async with aiosqlite.connect(db_path) as db:
+        await store_champions_pokemon_data(db, pokemon_data)
+        await db.commit()
+
+    result = await get_champions_pokemon("charizard", db_path=db_path)
+    assert result is not None
+    assert result.name == "Charizard"
+    assert result.base_stats["spa"] == 159
+    assert result.is_mega is False
+
+
+@pytest.mark.asyncio
+async def test_get_champions_pokemon_with_megas(tmp_path):
+    """Query a Pokemon and its Mega forms."""
+    db_path = tmp_path / "test.db"
+    await init_database(db_path)
+
+    from smogon_vgc_mcp.fetcher.champions_dex import store_champions_pokemon_data
+    from smogon_vgc_mcp.database.queries import get_champions_pokemon_with_megas
+
+    pokemon_data = [
+        {
+            "pokemon_id": "charizard",
+            "num": 6, "name": "Charizard",
+            "types": ["Fire", "Flying"],
+            "base_stats": {"hp": 78, "atk": 104, "def": 98, "spa": 159, "spd": 115, "spe": 100},
+            "abilities": ["Blaze"], "ability_hidden": "Solar Power",
+            "height_m": 1.7, "weight_kg": 90.5,
+            "is_mega": False, "base_form_id": None, "mega_stone": None,
+        },
+        {
+            "pokemon_id": "charizard-mega-x",
+            "num": 6, "name": "Mega Charizard X",
+            "types": ["Fire", "Dragon"],
+            "base_stats": {"hp": 78, "atk": 170, "def": 131, "spa": 170, "spd": 115, "spe": 100},
+            "abilities": ["Tough Claws"], "ability_hidden": None,
+            "height_m": 1.7, "weight_kg": 110.5,
+            "is_mega": True, "base_form_id": "charizard", "mega_stone": "Charizardite X",
+        },
+    ]
+
+    async with aiosqlite.connect(db_path) as db:
+        await store_champions_pokemon_data(db, pokemon_data)
+        await db.commit()
+
+    base, megas = await get_champions_pokemon_with_megas("charizard", db_path=db_path)
+    assert base is not None
+    assert base.name == "Charizard"
+    assert len(megas) == 1
+    assert megas[0].name == "Mega Charizard X"
+    assert megas[0].mega_stone == "Charizardite X"
+
+
+@pytest.mark.asyncio
+async def test_search_champions_pokemon_by_type(tmp_path):
+    """Search Champions Pokemon by type."""
+    db_path = tmp_path / "test.db"
+    await init_database(db_path)
+
+    from smogon_vgc_mcp.fetcher.champions_dex import store_champions_pokemon_data
+    from smogon_vgc_mcp.database.queries import search_champions_pokemon_by_type
+
+    pokemon_data = [
+        {
+            "pokemon_id": "charizard", "num": 6, "name": "Charizard",
+            "types": ["Fire", "Flying"],
+            "base_stats": {"hp": 78, "atk": 104, "def": 98, "spa": 159, "spd": 115, "spe": 100},
+            "abilities": ["Blaze"], "ability_hidden": None,
+            "height_m": 1.7, "weight_kg": 90.5,
+            "is_mega": False, "base_form_id": None, "mega_stone": None,
+        },
+        {
+            "pokemon_id": "pikachu", "num": 25, "name": "Pikachu",
+            "types": ["Electric"],
+            "base_stats": {"hp": 55, "atk": 80, "def": 50, "spa": 75, "spd": 60, "spe": 110},
+            "abilities": ["Static"], "ability_hidden": "Lightning Rod",
+            "height_m": 0.4, "weight_kg": 6.0,
+            "is_mega": False, "base_form_id": None, "mega_stone": None,
+        },
+    ]
+
+    async with aiosqlite.connect(db_path) as db:
+        await store_champions_pokemon_data(db, pokemon_data)
+        await db.commit()
+
+    results = await search_champions_pokemon_by_type("Fire", db_path=db_path)
+    assert len(results) == 1
+    assert results[0].name == "Charizard"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_champions_dex_queries.py::test_get_champions_pokemon -v`
+Expected: FAIL — query functions don't exist
+
+- [ ] **Step 3: Implement query functions**
+
+Add to `src/smogon_vgc_mcp/database/queries.py`:
+
+```python
+from smogon_vgc_mcp.database.models import ChampionsDexPokemon
+
+
+def _row_to_champions_pokemon(row) -> ChampionsDexPokemon:
+    """Convert a database row to a ChampionsDexPokemon model."""
+    types = [row["type1"]]
+    if row["type2"]:
+        types.append(row["type2"])
+
+    abilities = []
+    if row["ability1"]:
+        abilities.append(row["ability1"])
+    if row["ability2"]:
+        abilities.append(row["ability2"])
+
+    return ChampionsDexPokemon(
+        id=row["id"],
+        num=row["num"],
+        name=row["name"],
+        types=types,
+        base_stats={
+            "hp": row["hp"],
+            "atk": row["atk"],
+            "def": row["def"],
+            "spa": row["spa"],
+            "spd": row["spd"],
+            "spe": row["spe"],
+        },
+        abilities=abilities,
+        ability_hidden=row["ability_hidden"],
+        height_m=row["height_m"] or 0.0,
+        weight_kg=row["weight_kg"] or 0.0,
+        is_mega=bool(row["is_mega"]),
+        base_form_id=row["base_form_id"],
+        mega_stone=row["mega_stone"],
+    )
+
+
+async def get_champions_pokemon(
+    pokemon_id: str,
+    db_path: Path | None = None,
+) -> ChampionsDexPokemon | None:
+    """Get a Champions Pokemon by ID."""
+    async with get_connection(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT * FROM champions_dex_pokemon WHERE id = ?",
+            (pokemon_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+            if row:
+                return _row_to_champions_pokemon(row)
+    return None
+
+
+async def get_champions_pokemon_with_megas(
+    pokemon_id: str,
+    db_path: Path | None = None,
+) -> tuple[ChampionsDexPokemon | None, list[ChampionsDexPokemon]]:
+    """Get a Champions Pokemon and all its Mega forms.
+
+    Returns:
+        Tuple of (base_form, [mega_forms])
+    """
+    base = await get_champions_pokemon(pokemon_id, db_path=db_path)
+    megas: list[ChampionsDexPokemon] = []
+
+    async with get_connection(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT * FROM champions_dex_pokemon WHERE base_form_id = ?",
+            (pokemon_id,),
+        ) as cursor:
+            async for row in cursor:
+                megas.append(_row_to_champions_pokemon(row))
+
+    return base, megas
+
+
+async def search_champions_pokemon_by_type(
+    type_name: str,
+    db_path: Path | None = None,
+) -> list[ChampionsDexPokemon]:
+    """Search Champions Pokemon by type (primary or secondary)."""
+    async with get_connection(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT * FROM champions_dex_pokemon WHERE type1 = ? OR type2 = ? ORDER BY name",
+            (type_name, type_name),
+        ) as cursor:
+            return [_row_to_champions_pokemon(row) async for row in cursor]
+```
+
+- [ ] **Step 4: Add import for ChampionsDexPokemon to queries.py imports**
+
+In the imports at the top of `queries.py`, add `ChampionsDexPokemon` to the import from `models`:
+
+```python
+from smogon_vgc_mcp.database.models import (
+    ...,
+    ChampionsDexPokemon,
+)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_champions_dex_queries.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/database/queries.py tests/test_champions_dex_queries.py
+git commit -m "feat: add Champions Pokedex query functions (#6)"
+```
+
+---
+
+### Task 9: Uncomment Champions FormatConfig entry
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/formats.py`
+- Modify: `tests/test_formats.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_formats.py`:
+
+```python
+def test_champions_format_exists():
+    """Champions M-A format should be registered."""
+    from smogon_vgc_mcp.formats import get_format
+
+    fmt = get_format("champions_ma")
+    assert fmt.generation == 10
+    assert fmt.stat_system == "champions_sp"
+    assert fmt.calc_backend == "python_native"
+    assert fmt.smogon_stats_available is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_formats.py::test_champions_format_exists -v`
+Expected: FAIL — `ValueError: Unknown format: champions_ma`
+
+- [ ] **Step 3: Uncomment the Champions FormatConfig in formats.py**
+
+In `src/smogon_vgc_mcp/formats.py`, replace the commented block with:
+
+```python
+    "champions_ma": FormatConfig(
+        code="champions_ma",
+        name="Champions Regulation M-A",
+        smogon_format_id="",
+        available_months=[],
+        generation=10,
+        stat_system="champions_sp",
+        calc_backend="python_native",
+        smogon_stats_available=False,
+        is_current=False,
+    ),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_formats.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full type check and lint**
+
+Run: `uv run ruff check --fix . && uv run ruff format .`
+Run: `uv run ty check`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/formats.py tests/test_formats.py
+git commit -m "feat: register Champions M-A format in FormatConfig (#6)"
+```
+
+---
+
+### Task 10: Full test suite verification + lint
+
+**Files:** None — verification only
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `uv run pytest tests/ -v --tb=short`
+Expected: All tests PASS, including all new Champions tests
+
+- [ ] **Step 2: Run linter**
+
+Run: `uv run ruff check --fix . && uv run ruff format .`
+Expected: No errors
+
+- [ ] **Step 3: Run type checker**
+
+Run: `uv run ty check`
+Expected: No errors (or only pre-existing ones)
+
+- [ ] **Step 4: Fix any issues found**
+
+If any tests fail, lint errors, or type errors — fix them and commit:
+
+```bash
+git add -u
+git commit -m "fix: resolve lint/type errors from Champions Pokedex pipeline (#6)"
+```
+
+- [ ] **Step 5: Close issue #5 (spike complete)**
+
+The data source spike (#5) was completed last session. Close it:
+
+```bash
+gh issue close 5 --comment "Spike complete: Serebii confirmed as Champions Pokedex data source. Implemented in Phase 1 (#6)."
+```

--- a/docs/superpowers/plans/2026-04-08-champions-stat-calculator.md
+++ b/docs/superpowers/plans/2026-04-08-champions-stat-calculator.md
@@ -1,0 +1,1588 @@
+# Champions Stat Calculator & Speed Tiers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build Champions-specific stat calculator using the Stat Points (SP) system, SP optimizer for optimal allocation, and speed tier tools using Champions benchmark data.
+
+**Architecture:** Separate calculator modules (`champions_stats.py`, `champions_speed.py`, `champions_sp_optimizer.py`) that mirror the Gen 9 calculator structure but use the Champions SP formula instead of EVs/IVs. MCP tools registered in a new `tools/champions_calculator.py`. Base stats looked up from Phase 1's `champions_dex_pokemon` SQLite table via existing query functions.
+
+**Tech Stack:** Python 3.12, math (stdlib), aiosqlite (base stats lookup), pytest, mcp.server.fastmcp
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `src/smogon_vgc_mcp/calculator/champions_stats.py` | Champions stat formulas (HP + other stats with SP and nature) |
+| `src/smogon_vgc_mcp/calculator/champions_speed.py` | Speed tier benchmarks, comparisons, and EV-finding for Champions |
+| `src/smogon_vgc_mcp/calculator/champions_sp_optimizer.py` | SP allocation optimizer (speed benchmarks, HP thresholds, bulk) |
+| `src/smogon_vgc_mcp/tools/champions_calculator.py` | MCP tool registrations for Champions calculator tools |
+| `tests/test_champions_stats.py` | Unit tests for stat calculator |
+| `tests/test_champions_speed.py` | Unit tests for speed tier tools |
+| `tests/test_champions_sp_optimizer.py` | Unit tests for SP optimizer |
+| `tests/test_champions_calculator_tools.py` | Integration tests for MCP tools |
+
+---
+
+## Context: Champions Stat System
+
+**Stat Points (SP):** Each Pokemon gets 66 total SP, max 32 per stat. No IVs. Replaces EVs/IVs from Gen 9.
+
+**Non-HP formula:** `floor(floor((2 * base) * level / 100) + 5) * nature_multiplier) + sp`
+- Nature multiplier: 1.1 (boosted), 0.9 (reduced), 1.0 (neutral)
+- SP added AFTER nature multiplier (confirmed from game data)
+- At level 50: `floor((base + 5) * nature) + sp`
+
+**HP formula:** `floor((2 * base) * level / 100) + level + 10 + sp`
+- No nature multiplier on HP (same as mainline games)
+- At level 50: `base + 60 + sp`
+
+**Nature system:** Same 25 natures as mainline (Adamant, Jolly, etc.) with same stat modifiers (1.1/0.9). Reuses existing `get_nature_multiplier()` from `data/pokemon_data.py`.
+
+**Speed tier data:** Pre-computed benchmarks stored in `memory/reference_champions_speed_tiers.md`. Key tiers: Excadrill Sand Rush 280, Venusaur Chlorophyll 264, Dragapult 213, uninvested Incineroar 112.
+
+---
+
+### Task 1: Champions Stat Calculator — Core Formulas
+
+**Files:**
+- Create: `src/smogon_vgc_mcp/calculator/champions_stats.py`
+- Create: `tests/test_champions_stats.py`
+
+- [ ] **Step 1: Write failing tests for `calculate_champions_hp()`**
+
+```python
+"""Tests for Champions stat calculator."""
+
+import pytest
+
+from smogon_vgc_mcp.calculator.champions_stats import (
+    calculate_champions_hp,
+    calculate_champions_stat,
+    calculate_all_champions_stats,
+    format_champions_stats,
+)
+
+
+class TestCalculateChampionsHp:
+    """Tests for calculate_champions_hp()."""
+
+    def test_base_100_no_sp(self):
+        # floor((2*100)*50/100) + 50 + 10 + 0 = 100 + 60 = 160
+        assert calculate_champions_hp(base=100, sp=0, level=50) == 160
+
+    def test_base_100_max_sp(self):
+        # 100 + 60 + 32 = 192
+        assert calculate_champions_hp(base=100, sp=32, level=50) == 192
+
+    def test_base_80_incineroar(self):
+        # floor((2*80)*50/100) + 50 + 10 + 0 = 80 + 60 = 140
+        assert calculate_champions_hp(base=80, sp=0, level=50) == 140
+
+    def test_base_80_max_sp(self):
+        # 80 + 60 + 32 = 172
+        assert calculate_champions_hp(base=80, sp=32, level=50) == 172
+
+    def test_shedinja_1_hp(self):
+        # Shedinja always has 1 HP regardless of anything
+        assert calculate_champions_hp(base=1, sp=0, level=50) == 62
+        # Note: Shedinja's 1 HP is enforced at a higher level, not in the formula
+
+    def test_level_100(self):
+        # floor((2*100)*100/100) + 100 + 10 + 0 = 200 + 110 = 310
+        assert calculate_champions_hp(base=100, sp=0, level=100) == 310
+
+    def test_sp_must_be_0_to_32(self):
+        with pytest.raises(ValueError, match="SP must be between 0 and 32"):
+            calculate_champions_hp(base=100, sp=33, level=50)
+
+    def test_sp_negative_raises(self):
+        with pytest.raises(ValueError, match="SP must be between 0 and 32"):
+            calculate_champions_hp(base=100, sp=-1, level=50)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_champions_stats.py::TestCalculateChampionsHp -v`
+Expected: FAIL with `ModuleNotFoundError` or `ImportError`
+
+- [ ] **Step 3: Implement `calculate_champions_hp()`**
+
+```python
+"""Champions stat calculator using Stat Points (SP) system.
+
+Champions uses 66 total SP (max 32/stat) instead of EVs/IVs.
+HP formula: floor((2 * base) * level / 100) + level + 10 + sp
+Non-HP formula: floor((floor((2 * base) * level / 100) + 5) * nature) + sp
+"""
+
+import math
+
+MAX_SP_PER_STAT = 32
+MAX_TOTAL_SP = 66
+
+
+def calculate_champions_hp(base: int, sp: int = 0, level: int = 50) -> int:
+    """Calculate Champions HP stat.
+
+    Formula: floor((2 * base) * level / 100) + level + 10 + sp
+    """
+    if not 0 <= sp <= MAX_SP_PER_STAT:
+        raise ValueError(
+            f"SP must be between 0 and {MAX_SP_PER_STAT}, got {sp}"
+        )
+    return math.floor((2 * base) * level / 100) + level + 10 + sp
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_champions_stats.py::TestCalculateChampionsHp -v`
+Expected: PASS
+
+- [ ] **Step 5: Write failing tests for `calculate_champions_stat()`**
+
+Add to `tests/test_champions_stats.py`:
+
+```python
+class TestCalculateChampionsStat:
+    """Tests for calculate_champions_stat() (non-HP stats)."""
+
+    def test_base_100_neutral_no_sp(self):
+        # floor((floor((2*100)*50/100) + 5) * 1.0) + 0 = 105
+        assert calculate_champions_stat(base=100, sp=0, level=50) == 105
+
+    def test_base_100_neutral_max_sp(self):
+        # floor((floor((2*100)*50/100) + 5) * 1.0) + 32 = 137
+        assert calculate_champions_stat(
+            base=100, sp=32, level=50
+        ) == 137
+
+    def test_base_100_boosted_nature(self):
+        # floor((floor((2*100)*50/100) + 5) * 1.1) + 0 = floor(115.5) = 115
+        assert calculate_champions_stat(
+            base=100, sp=0, nature_multiplier=1.1, level=50
+        ) == 115
+
+    def test_base_100_reduced_nature(self):
+        # floor((floor((2*100)*50/100) + 5) * 0.9) + 0 = floor(94.5) = 94
+        assert calculate_champions_stat(
+            base=100, sp=0, nature_multiplier=0.9, level=50
+        ) == 94
+
+    def test_base_80_boosted_max_sp(self):
+        # floor((floor((2*80)*50/100) + 5) * 1.1) + 32
+        # = floor(85 * 1.1) + 32 = floor(93.5) + 32 = 93 + 32 = 125
+        assert calculate_champions_stat(
+            base=80, sp=32, nature_multiplier=1.1, level=50
+        ) == 125
+
+    def test_sp_added_after_nature(self):
+        # Verify SP is added after nature multiplier, not before
+        # base=100, sp=10, boosted:
+        # floor((105) * 1.1) + 10 = floor(115.5) + 10 = 125
+        result = calculate_champions_stat(
+            base=100, sp=10, nature_multiplier=1.1, level=50
+        )
+        assert result == 125
+
+    def test_sp_validation(self):
+        with pytest.raises(ValueError, match="SP must be between 0 and 32"):
+            calculate_champions_stat(base=100, sp=33, level=50)
+
+    def test_incineroar_speed_base_60_neutral(self):
+        # floor((floor((2*60)*50/100) + 5) * 1.0) + 0 = 65
+        assert calculate_champions_stat(base=60, sp=0, level=50) == 65
+
+    def test_incineroar_speed_max_sp_neutral(self):
+        # 65 + 32 = 97
+        assert calculate_champions_stat(base=60, sp=32, level=50) == 97
+```
+
+- [ ] **Step 6: Implement `calculate_champions_stat()`**
+
+Add to `champions_stats.py`:
+
+```python
+def calculate_champions_stat(
+    base: int,
+    sp: int = 0,
+    nature_multiplier: float = 1.0,
+    level: int = 50,
+) -> int:
+    """Calculate a Champions non-HP stat (Atk, Def, SpA, SpD, Spe).
+
+    Formula: floor((floor((2 * base) * level / 100) + 5) * nature) + sp
+    SP is added AFTER the nature multiplier.
+    """
+    if not 0 <= sp <= MAX_SP_PER_STAT:
+        raise ValueError(
+            f"SP must be between 0 and {MAX_SP_PER_STAT}, got {sp}"
+        )
+    raw = math.floor((2 * base) * level / 100) + 5
+    return math.floor(raw * nature_multiplier) + sp
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_champions_stats.py::TestCalculateChampionsStat -v`
+Expected: PASS
+
+- [ ] **Step 8: Write failing tests for `calculate_all_champions_stats()`**
+
+Add to `tests/test_champions_stats.py`:
+
+```python
+class TestCalculateAllChampionsStats:
+    """Tests for calculate_all_champions_stats()."""
+
+    def test_all_zero_sp_neutral(self):
+        base_stats = {
+            "hp": 80, "atk": 82, "def": 83,
+            "spa": 100, "spd": 100, "spe": 80,
+        }
+        sp_spread = {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+        result = calculate_all_champions_stats(base_stats, sp_spread, "Hardy")
+        assert result["hp"] == 140  # 80 + 60
+        assert result["spe"] == 85  # 80 + 5
+
+    def test_max_sp_modest(self):
+        base_stats = {
+            "hp": 80, "atk": 82, "def": 83,
+            "spa": 100, "spd": 100, "spe": 80,
+        }
+        sp_spread = {
+            "hp": 32, "atk": 0, "def": 0,
+            "spa": 32, "spd": 0, "spe": 2,
+        }
+        result = calculate_all_champions_stats(base_stats, sp_spread, "Modest")
+        assert result["hp"] == 172  # 140 + 32
+        # spa: floor(105 * 1.1) + 32 = 115 + 32 = 147
+        assert result["spa"] == 147
+        # atk: floor(87 * 0.9) + 0 = floor(78.3) = 78
+        assert result["atk"] == 78
+        assert result["spe"] == 87  # 85 + 2
+
+    def test_sp_total_validation(self):
+        base_stats = {
+            "hp": 100, "atk": 100, "def": 100,
+            "spa": 100, "spd": 100, "spe": 100,
+        }
+        # 32 * 3 = 96 > 66
+        sp_spread = {
+            "hp": 32, "atk": 32, "def": 32,
+            "spa": 0, "spd": 0, "spe": 0,
+        }
+        with pytest.raises(ValueError, match="Total SP must not exceed 66"):
+            calculate_all_champions_stats(base_stats, sp_spread, "Hardy")
+
+    def test_returns_none_for_invalid_nature(self):
+        base_stats = {
+            "hp": 100, "atk": 100, "def": 100,
+            "spa": 100, "spd": 100, "spe": 100,
+        }
+        sp_spread = {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+        result = calculate_all_champions_stats(
+            base_stats, sp_spread, "NotANature"
+        )
+        assert result is None
+```
+
+- [ ] **Step 9: Implement `calculate_all_champions_stats()` and `format_champions_stats()`**
+
+Add to `champions_stats.py`:
+
+```python
+from smogon_vgc_mcp.data.pokemon_data import get_nature_multiplier
+
+STAT_ORDER = ["hp", "atk", "def", "spa", "spd", "spe"]
+STAT_NAMES = {
+    "hp": "HP", "atk": "Atk", "def": "Def",
+    "spa": "SpA", "spd": "SpD", "spe": "Spe",
+}
+
+
+def calculate_all_champions_stats(
+    base_stats: dict[str, int],
+    sp_spread: dict[str, int],
+    nature: str,
+    level: int = 50,
+) -> dict[str, int] | None:
+    """Calculate all 6 stats for a Champions Pokemon.
+
+    Args:
+        base_stats: Dict with hp, atk, def, spa, spd, spe base values.
+        sp_spread: Dict with hp, atk, def, spa, spd, spe SP values (0-32 each).
+        nature: Nature name (e.g., "Adamant", "Modest", "Hardy").
+        level: Pokemon level (default 50).
+
+    Returns:
+        Dict of calculated stats, or None if nature is invalid.
+    """
+    total_sp = sum(sp_spread.get(s, 0) for s in STAT_ORDER)
+    if total_sp > MAX_TOTAL_SP:
+        raise ValueError(
+            f"Total SP must not exceed {MAX_TOTAL_SP}, got {total_sp}"
+        )
+
+    # Validate nature exists by checking if it returns a valid multiplier
+    # Neutral natures return 1.0 for all stats, which is fine
+    from smogon_vgc_mcp.data.pokemon_data import get_nature_modifiers
+    if nature.lower() not in [
+        "hardy", "lonely", "brave", "adamant", "naughty",
+        "bold", "docile", "relaxed", "impish", "lax",
+        "timid", "hasty", "serious", "jolly", "naive",
+        "modest", "mild", "quiet", "bashful", "rash",
+        "calm", "gentle", "sassy", "careful", "quirky",
+    ]:
+        return None
+
+    stats = {}
+    for stat in STAT_ORDER:
+        base = base_stats[stat]
+        sp = sp_spread.get(stat, 0)
+        if stat == "hp":
+            stats[stat] = calculate_champions_hp(base, sp, level)
+        else:
+            mult = get_nature_multiplier(nature, stat)
+            stats[stat] = calculate_champions_stat(base, sp, mult, level)
+
+    return stats
+
+
+def format_champions_stats(stats: dict[str, int]) -> str:
+    """Format calculated stats as a readable string.
+
+    Example: 'HP: 172 / Atk: 78 / Def: 88 / SpA: 147 / SpD: 105 / Spe: 87'
+    """
+    parts = []
+    for stat in STAT_ORDER:
+        name = STAT_NAMES[stat]
+        parts.append(f"{name}: {stats[stat]}")
+    return " / ".join(parts)
+```
+
+- [ ] **Step 10: Run all Task 1 tests**
+
+Run: `uv run python -m pytest tests/test_champions_stats.py -v`
+Expected: All PASS
+
+- [ ] **Step 11: Lint check**
+
+Run: `uv run ruff check src/smogon_vgc_mcp/calculator/champions_stats.py tests/test_champions_stats.py && uv run ruff format --check src/smogon_vgc_mcp/calculator/champions_stats.py tests/test_champions_stats.py`
+Expected: Clean
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/calculator/champions_stats.py tests/test_champions_stats.py
+git commit -m "feat: add Champions stat calculator with SP system"
+```
+
+---
+
+### Task 2: Champions Speed Tiers
+
+**Files:**
+- Create: `src/smogon_vgc_mcp/calculator/champions_speed.py`
+- Create: `tests/test_champions_speed.py`
+
+- [ ] **Step 1: Write failing tests for speed calculation and benchmarks**
+
+```python
+"""Tests for Champions speed tier tools."""
+
+import pytest
+
+from smogon_vgc_mcp.calculator.champions_speed import (
+    CHAMPIONS_SPEED_TIERS,
+    get_champions_speed,
+    compare_champions_speeds,
+    find_champions_speed_benchmarks,
+    find_champions_speed_sp,
+)
+
+
+class TestGetChampionsSpeed:
+    """Tests for get_champions_speed()."""
+
+    def test_base_110_max_sp_positive_nature(self):
+        # Gengar: base 110, +nature, 32 SP
+        # floor((floor((2*110)*50/100) + 5) * 1.1) + 32
+        # = floor(115 * 1.1) + 32 = floor(126.5) + 32 = 126 + 32 = 158
+        assert get_champions_speed(base_spe=110, sp=32, nature="Timid") == 158
+
+    def test_base_60_no_sp_neutral(self):
+        # Incineroar: base 60, neutral, 0 SP
+        # floor((65) * 1.0) + 0 = 65
+        assert get_champions_speed(base_spe=60, sp=0, nature="Hardy") == 65
+
+    def test_base_60_max_sp_neutral(self):
+        # 65 + 32 = 97
+        assert get_champions_speed(base_spe=60, sp=32, nature="Hardy") == 97
+
+    def test_base_80_negative_nature_for_trick_room(self):
+        # Dragonite base 80, -spe nature, 0 SP
+        # floor((85) * 0.9) + 0 = floor(76.5) = 76
+        assert get_champions_speed(base_spe=80, sp=0, nature="Brave") == 76
+
+
+class TestCompareChampionsSpeeds:
+    """Tests for compare_champions_speeds()."""
+
+    def test_faster_pokemon_wins(self):
+        result = compare_champions_speeds(
+            pokemon1="Gengar", base_spe1=110, sp1=32, nature1="Timid",
+            pokemon2="Incineroar", base_spe2=60, sp2=0, nature2="Hardy",
+        )
+        assert result["result"] == "pokemon1_faster"
+        assert result["pokemon1"]["speed"] > result["pokemon2"]["speed"]
+
+    def test_speed_tie(self):
+        result = compare_champions_speeds(
+            pokemon1="PokemonA", base_spe1=100, sp1=0, nature1="Hardy",
+            pokemon2="PokemonB", base_spe2=100, sp2=0, nature2="Hardy",
+        )
+        assert result["result"] == "tie"
+
+    def test_slower_pokemon(self):
+        result = compare_champions_speeds(
+            pokemon1="Incineroar", base_spe1=60, sp1=0, nature1="Hardy",
+            pokemon2="Gengar", base_spe2=110, sp2=32, nature2="Timid",
+        )
+        assert result["result"] == "pokemon2_faster"
+
+
+class TestFindChampionsSpeedBenchmarks:
+    """Tests for find_champions_speed_benchmarks()."""
+
+    def test_returns_outspeeds_and_underspeeds(self):
+        result = find_champions_speed_benchmarks(
+            pokemon="TestMon", speed=150
+        )
+        assert "outspeeds" in result
+        assert "underspeeds" in result
+        assert "speed_ties" in result
+        assert result["speed"] == 150
+
+    def test_max_speed_outspeeds_many(self):
+        result = find_champions_speed_benchmarks(
+            pokemon="FastMon", speed=250
+        )
+        assert len(result["outspeeds"]) > 0
+
+    def test_min_speed_underspeeds_many(self):
+        result = find_champions_speed_benchmarks(
+            pokemon="SlowMon", speed=50
+        )
+        assert len(result["underspeeds"]) > 0
+
+
+class TestFindChampionsSpeedSp:
+    """Tests for find_champions_speed_sp()."""
+
+    def test_find_sp_to_outspeed(self):
+        # Find SP needed for base 80 to outspeed base 60 max speed
+        # Target: base 60, 32 SP, +nature = floor(65*1.1)+32 = 103
+        # Me: base 80, +nature: floor(85*1.1) + sp = 93 + sp
+        # Need 93 + sp > 103 → sp > 10 → sp = 11
+        result = find_champions_speed_sp(
+            base_spe=80,
+            target_speed=103,
+            nature="Jolly",
+            goal="outspeed",
+        )
+        assert result["success"] is True
+        assert result["sp_needed"] == 11
+        assert result["resulting_speed"] == 104
+
+    def test_find_sp_to_underspeed(self):
+        # Find SP for base 80 to underspeed 65 (base 60, neutral, 0 SP)
+        # Me: base 80, -nature: floor(85*0.9) + sp = 76 + sp
+        # Need 76 + sp < 65 → sp < -11 → impossible
+        result = find_champions_speed_sp(
+            base_spe=80,
+            target_speed=65,
+            nature="Brave",
+            goal="underspeed",
+        )
+        assert result["success"] is False
+
+    def test_already_outspeeds(self):
+        # base 110 + nature already outspeeds 100
+        result = find_champions_speed_sp(
+            base_spe=110,
+            target_speed=100,
+            nature="Timid",
+            goal="outspeed",
+        )
+        assert result["success"] is True
+        assert result["sp_needed"] == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_champions_speed.py -v`
+Expected: FAIL with `ImportError`
+
+- [ ] **Step 3: Implement `champions_speed.py`**
+
+```python
+"""Champions speed tier tools.
+
+Speed tiers from the Champions VGC meta. Uses Champions stat formula
+with Stat Points instead of EVs/IVs.
+"""
+
+from smogon_vgc_mcp.calculator.champions_stats import calculate_champions_stat
+from smogon_vgc_mcp.data.pokemon_data import get_nature_multiplier
+
+# Champions speed benchmarks: (final_speed, pokemon_name, notes)
+# Source: memory/reference_champions_speed_tiers.md
+CHAMPIONS_SPEED_TIERS: list[tuple[int, str, str]] = [
+    (280, "Excadrill", "Sand Rush"),
+    (264, "Venusaur", "Chlorophyll/Tailwind"),
+    (264, "Dragonite", "Tailwind"),
+    (264, "Mega Meganium", "Tailwind"),
+    (264, "Eelektross", "Tailwind"),
+    (260, "Basculegion", "Swift Swim/Shell Smash"),
+    (260, "Mega Blastoise", "Swift Swim"),
+    (256, "Pelipper", "Tailwind"),
+    (254, "Mega Scizor", "Tailwind"),
+    (250, "Mega Charizard X", "Dragon Dance"),
+    (250, "Volcarona", "Quiver Dance"),
+    (244, "Mega Swampert", "Swift Swim"),
+    (243, "Gengar", "Choice Scarf"),
+    (228, "Mega Charizard X", "Dragon Dance (1 boost)"),
+    (228, "Volcarona", "Quiver Dance (1 boost)"),
+    (224, "Primarina", "Tailwind"),
+    (224, "Incineroar", "Tailwind"),
+    (224, "Aegislash", "Tailwind"),
+    (224, "Sylveon", "Tailwind"),
+    (223, "Mega Lucario", "Max Speed"),
+    (223, "Mega Garchomp", "Max Speed"),
+    (222, "Mega Aerodactyl", "Max Speed"),
+    (222, "Mega Alakazam", "Max Speed"),
+    (213, "Dragapult", "Max Speed"),
+    (213, "Mega Greninja", "Max Speed"),
+    (205, "Mega Manectric", "Max Speed"),
+    (205, "Mega Lopunny", "Max Speed"),
+    (200, "Mega Gengar", "Max Speed"),
+    (200, "Mega Raichu Y", "Max Speed"),
+    (195, "Talonflame", "Max Speed"),
+    (194, "Weavile", "Max Speed"),
+    (192, "Meowscarada", "Max Speed"),
+    (191, "Greninja", "Max Speed"),
+    (152, "Mega Charizard X", "Max Speed (unboosted)"),
+    (152, "Mega Dragonite", "Max Speed"),
+    (150, "Hydreigon", "Max Speed"),
+    (150, "Archaludon", "Max Speed"),
+    (150, "Kommo-o", "Max Speed"),
+    (150, "Ceruledge", "Max Speed"),
+    (137, "Archaludon", "Neutral Max SP"),
+    (137, "Kommo-o", "Neutral Max SP"),
+    (137, "Ceruledge", "Neutral Max SP"),
+    (132, "Altaria", "Max Speed"),
+    (132, "Dragonite", "Max Speed"),
+    (132, "Mega Meganium", "Max Speed"),
+    (132, "Chandelure", "Max Speed"),
+    (112, "Primarina", "Max Speed"),
+    (112, "Incineroar", "Max Speed"),
+    (112, "Aegislash", "Max Speed"),
+    (112, "Sylveon", "Max Speed"),
+    (102, "Kingambit", "Max Speed"),
+    (102, "Azumarill", "Max Speed"),
+]
+
+
+def get_champions_speed(
+    base_spe: int,
+    sp: int = 0,
+    nature: str = "Hardy",
+    level: int = 50,
+) -> int:
+    """Calculate Champions speed stat."""
+    mult = get_nature_multiplier(nature, "spe")
+    return calculate_champions_stat(base_spe, sp, mult, level)
+
+
+def compare_champions_speeds(
+    pokemon1: str,
+    base_spe1: int,
+    sp1: int,
+    nature1: str,
+    pokemon2: str,
+    base_spe2: int,
+    sp2: int,
+    nature2: str,
+    level: int = 50,
+) -> dict:
+    """Compare speed between two Champions Pokemon."""
+    speed1 = get_champions_speed(base_spe1, sp1, nature1, level)
+    speed2 = get_champions_speed(base_spe2, sp2, nature2, level)
+
+    if speed1 > speed2:
+        result = "pokemon1_faster"
+    elif speed2 > speed1:
+        result = "pokemon2_faster"
+    else:
+        result = "tie"
+
+    return {
+        "pokemon1": {"name": pokemon1, "speed": speed1},
+        "pokemon2": {"name": pokemon2, "speed": speed2},
+        "result": result,
+        "difference": abs(speed1 - speed2),
+    }
+
+
+def find_champions_speed_benchmarks(
+    pokemon: str, speed: int
+) -> dict:
+    """Find what Champions meta Pokemon a speed stat outspeeds."""
+    outspeeds = []
+    underspeeds = []
+    speed_ties = []
+
+    seen = set()
+    for tier_speed, name, notes in CHAMPIONS_SPEED_TIERS:
+        key = (tier_speed, name)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        entry = {"pokemon": name, "speed": tier_speed, "notes": notes}
+        if speed > tier_speed:
+            outspeeds.append(entry)
+        elif speed < tier_speed:
+            underspeeds.append(entry)
+        else:
+            speed_ties.append(entry)
+
+    return {
+        "pokemon": pokemon,
+        "speed": speed,
+        "outspeeds": outspeeds,
+        "underspeeds": underspeeds,
+        "speed_ties": speed_ties,
+    }
+
+
+def find_champions_speed_sp(
+    base_spe: int,
+    target_speed: int,
+    nature: str = "Jolly",
+    goal: str = "outspeed",
+    level: int = 50,
+) -> dict:
+    """Find minimum SP needed to outspeed or underspeed a target."""
+    mult = get_nature_multiplier(nature, "spe")
+    raw = __import__("math").floor(
+        __import__("math").floor((2 * base_spe) * level / 100) + 5
+    )
+    base_speed_no_sp = __import__("math").floor(raw * mult)
+
+    if goal == "outspeed":
+        needed = target_speed + 1 - base_speed_no_sp
+        if needed < 0:
+            needed = 0
+        if needed > 32:
+            return {
+                "success": False,
+                "reason": (
+                    f"Cannot outspeed {target_speed} even with 32 SP "
+                    f"(max speed: {base_speed_no_sp + 32})"
+                ),
+            }
+        return {
+            "success": True,
+            "sp_needed": needed,
+            "resulting_speed": base_speed_no_sp + needed,
+            "target_speed": target_speed,
+        }
+    else:  # underspeed
+        needed_max = target_speed - 1 - base_speed_no_sp
+        if needed_max < 0:
+            return {
+                "success": False,
+                "reason": (
+                    f"Cannot underspeed {target_speed} "
+                    f"(min speed: {base_speed_no_sp})"
+                ),
+            }
+        return {
+            "success": True,
+            "sp_needed": 0,
+            "resulting_speed": base_speed_no_sp,
+            "target_speed": target_speed,
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_champions_speed.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Lint check**
+
+Run: `uv run ruff check src/smogon_vgc_mcp/calculator/champions_speed.py tests/test_champions_speed.py && uv run ruff format --check src/smogon_vgc_mcp/calculator/champions_speed.py tests/test_champions_speed.py`
+Expected: Clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/calculator/champions_speed.py tests/test_champions_speed.py
+git commit -m "feat: add Champions speed tier tools and benchmarks"
+```
+
+---
+
+### Task 3: Champions SP Optimizer
+
+**Files:**
+- Create: `src/smogon_vgc_mcp/calculator/champions_sp_optimizer.py`
+- Create: `tests/test_champions_sp_optimizer.py`
+
+- [ ] **Step 1: Write failing tests for SP optimizer**
+
+```python
+"""Tests for Champions SP optimizer."""
+
+import pytest
+
+from smogon_vgc_mcp.calculator.champions_sp_optimizer import (
+    optimize_champions_sp,
+    suggest_hp_sp,
+    SpGoal,
+    SpeedGoal,
+    MaximizeGoal,
+    HpThresholdGoal,
+)
+
+
+class TestSuggestHpSp:
+    """Tests for HP SP optimization based on divisibility rules."""
+
+    def test_leftovers_optimization(self):
+        # base HP 80: floor((2*80)*50/100) + 60 = 140
+        # Want HP % 16 == 0 for max Leftovers
+        # 140 % 16 == 12, need +4 → 144 % 16 == 0
+        result = suggest_hp_sp(base_hp=80, item="Leftovers")
+        assert result["recommended_sp"] == 4
+        assert result["resulting_hp"] % 16 == 0
+        assert result["resulting_hp"] == 144
+
+    def test_life_orb_optimization(self):
+        # base HP 80: 140
+        # Want HP % 10 == 1 for min Life Orb recoil
+        # 140 % 10 == 0, need +1 → 141 % 10 == 1
+        result = suggest_hp_sp(base_hp=80, item="Life Orb")
+        assert result["recommended_sp"] == 1
+        assert result["resulting_hp"] % 10 == 1
+        assert result["resulting_hp"] == 141
+
+    def test_no_item_returns_zero(self):
+        result = suggest_hp_sp(base_hp=80, item=None)
+        assert result["recommended_sp"] == 0
+
+    def test_sitrus_belly_drum(self):
+        # Want HP % 4 == 0 for Sitrus + Belly Drum
+        result = suggest_hp_sp(base_hp=80, item="Sitrus Berry")
+        assert result["resulting_hp"] % 4 == 0
+
+    def test_sp_capped_at_32(self):
+        # Even if optimization wants more, cap at 32
+        result = suggest_hp_sp(base_hp=80, item="Leftovers")
+        assert result["recommended_sp"] <= 32
+
+
+class TestOptimizeChampionsSp:
+    """Tests for full SP optimizer."""
+
+    def test_single_speed_goal(self):
+        result = optimize_champions_sp(
+            base_stats={
+                "hp": 80, "atk": 82, "def": 83,
+                "spa": 100, "spd": 100, "spe": 80,
+            },
+            nature="Modest",
+            goals=[SpeedGoal(target_speed=132, mode="outspeed")],
+        )
+        assert result["success"] is True
+        assert result["sp_spread"]["spe"] > 0
+        total = sum(result["sp_spread"].values())
+        assert total <= 66
+
+    def test_maximize_spa_after_speed(self):
+        result = optimize_champions_sp(
+            base_stats={
+                "hp": 80, "atk": 82, "def": 83,
+                "spa": 100, "spd": 100, "spe": 80,
+            },
+            nature="Modest",
+            goals=[
+                SpeedGoal(target_speed=100, mode="outspeed"),
+                MaximizeGoal(stat="spa"),
+            ],
+        )
+        assert result["success"] is True
+        assert result["sp_spread"]["spa"] > 0
+        total = sum(result["sp_spread"].values())
+        assert total <= 66
+
+    def test_hp_threshold_goal(self):
+        result = optimize_champions_sp(
+            base_stats={
+                "hp": 80, "atk": 82, "def": 83,
+                "spa": 100, "spd": 100, "spe": 80,
+            },
+            nature="Modest",
+            goals=[HpThresholdGoal(item="Leftovers")],
+        )
+        assert result["success"] is True
+        hp_sp = result["sp_spread"]["hp"]
+        resulting_hp = 140 + hp_sp  # base 80 at lv50 = 140
+        assert resulting_hp % 16 == 0
+
+    def test_impossible_goals_reports_failure(self):
+        result = optimize_champions_sp(
+            base_stats={
+                "hp": 80, "atk": 82, "def": 83,
+                "spa": 100, "spd": 100, "spe": 80,
+            },
+            nature="Modest",
+            goals=[SpeedGoal(target_speed=300, mode="outspeed")],
+        )
+        assert result["success"] is False
+
+    def test_total_sp_never_exceeds_66(self):
+        result = optimize_champions_sp(
+            base_stats={
+                "hp": 80, "atk": 82, "def": 83,
+                "spa": 100, "spd": 100, "spe": 80,
+            },
+            nature="Modest",
+            goals=[
+                SpeedGoal(target_speed=100, mode="outspeed"),
+                HpThresholdGoal(item="Leftovers"),
+                MaximizeGoal(stat="spa"),
+            ],
+        )
+        total = sum(result["sp_spread"].values())
+        assert total <= 66
+        for v in result["sp_spread"].values():
+            assert 0 <= v <= 32
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_champions_sp_optimizer.py -v`
+Expected: FAIL with `ImportError`
+
+- [ ] **Step 3: Implement `champions_sp_optimizer.py`**
+
+```python
+"""Champions SP allocation optimizer.
+
+Allocates 66 total Stat Points across 6 stats (max 32 each)
+based on prioritized goals: speed thresholds, HP optimization,
+and stat maximization.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from smogon_vgc_mcp.calculator.champions_stats import (
+    MAX_SP_PER_STAT,
+    MAX_TOTAL_SP,
+    STAT_ORDER,
+    calculate_champions_hp,
+    calculate_champions_stat,
+)
+from smogon_vgc_mcp.data.pokemon_data import get_nature_multiplier
+
+
+@dataclass
+class SpeedGoal:
+    """Reach a speed threshold."""
+
+    target_speed: int
+    mode: str = "outspeed"  # "outspeed" or "underspeed"
+
+
+@dataclass
+class MaximizeGoal:
+    """Maximize a specific stat with remaining SP."""
+
+    stat: str  # hp, atk, def, spa, spd, spe
+
+
+@dataclass
+class HpThresholdGoal:
+    """Optimize HP for item interaction."""
+
+    item: str  # "Leftovers", "Life Orb", "Sitrus Berry"
+
+
+SpGoal = SpeedGoal | MaximizeGoal | HpThresholdGoal
+
+
+def suggest_hp_sp(
+    base_hp: int, item: str | None = None, level: int = 50
+) -> dict:
+    """Suggest HP SP investment based on item divisibility rules."""
+    base_hp_stat = calculate_champions_hp(base_hp, sp=0, level=level)
+
+    if item is None:
+        return {
+            "recommended_sp": 0,
+            "resulting_hp": base_hp_stat,
+            "reason": "No item specified",
+        }
+
+    item_lower = item.lower()
+
+    if item_lower in ("leftovers", "black sludge"):
+        # Want HP % 16 == 0
+        divisor, target_remainder = 16, 0
+        reason = "Maximizes Leftovers recovery (1/16 per turn)"
+    elif item_lower == "life orb":
+        # Want HP % 10 == 1
+        divisor, target_remainder = 10, 1
+        reason = "Minimizes Life Orb recoil (1/10 rounds down)"
+    elif item_lower == "sitrus berry":
+        # Want HP % 4 == 0
+        divisor, target_remainder = 4, 0
+        reason = "Maximizes Sitrus Berry recovery (1/4 HP)"
+    else:
+        return {
+            "recommended_sp": 0,
+            "resulting_hp": base_hp_stat,
+            "reason": f"No HP optimization rule for {item}",
+        }
+
+    current_remainder = base_hp_stat % divisor
+    if current_remainder == target_remainder:
+        return {
+            "recommended_sp": 0,
+            "resulting_hp": base_hp_stat,
+            "reason": f"Already optimal for {item}",
+        }
+
+    sp_needed = (target_remainder - current_remainder) % divisor
+    if sp_needed > MAX_SP_PER_STAT:
+        # Find next valid target
+        sp_needed = sp_needed % divisor or divisor
+
+    return {
+        "recommended_sp": min(sp_needed, MAX_SP_PER_STAT),
+        "resulting_hp": base_hp_stat + min(sp_needed, MAX_SP_PER_STAT),
+        "reason": reason,
+    }
+
+
+def optimize_champions_sp(
+    base_stats: dict[str, int],
+    nature: str,
+    goals: list[SpGoal],
+    level: int = 50,
+) -> dict:
+    """Optimize SP allocation based on prioritized goals.
+
+    Goals are processed in order. Each goal consumes SP from the
+    66-point budget. Remaining SP goes to the last MaximizeGoal
+    or is left unallocated.
+    """
+    sp_spread = {s: 0 for s in STAT_ORDER}
+    remaining = MAX_TOTAL_SP
+    goal_results = []
+
+    for goal in goals:
+        if isinstance(goal, SpeedGoal):
+            mult = get_nature_multiplier(nature, "spe")
+            raw = math.floor((2 * base_stats["spe"]) * level / 100) + 5
+            base_speed = math.floor(raw * mult)
+
+            if goal.mode == "outspeed":
+                sp_needed = goal.target_speed + 1 - base_speed
+                if sp_needed < 0:
+                    sp_needed = 0
+                if sp_needed > min(MAX_SP_PER_STAT, remaining):
+                    goal_results.append({
+                        "goal": f"Outspeed {goal.target_speed}",
+                        "achieved": False,
+                        "detail": (
+                            f"Need {sp_needed} Spe SP but only "
+                            f"{min(MAX_SP_PER_STAT, remaining)} available"
+                        ),
+                    })
+                    return {
+                        "success": False,
+                        "sp_spread": sp_spread,
+                        "remaining_sp": remaining,
+                        "goal_results": goal_results,
+                    }
+                sp_spread["spe"] = sp_needed
+                remaining -= sp_needed
+                goal_results.append({
+                    "goal": f"Outspeed {goal.target_speed}",
+                    "achieved": True,
+                    "sp_used": sp_needed,
+                    "resulting_speed": base_speed + sp_needed,
+                })
+            else:  # underspeed
+                # For underspeed, we want minimum speed, so 0 SP
+                goal_results.append({
+                    "goal": f"Underspeed {goal.target_speed}",
+                    "achieved": base_speed < goal.target_speed,
+                    "sp_used": 0,
+                    "resulting_speed": base_speed,
+                })
+                if base_speed >= goal.target_speed:
+                    return {
+                        "success": False,
+                        "sp_spread": sp_spread,
+                        "remaining_sp": remaining,
+                        "goal_results": goal_results,
+                    }
+
+        elif isinstance(goal, HpThresholdGoal):
+            hp_suggestion = suggest_hp_sp(
+                base_stats["hp"], goal.item, level
+            )
+            sp_needed = hp_suggestion["recommended_sp"]
+            sp_needed = min(sp_needed, remaining, MAX_SP_PER_STAT)
+            sp_spread["hp"] = sp_needed
+            remaining -= sp_needed
+            goal_results.append({
+                "goal": f"HP optimization for {goal.item}",
+                "achieved": True,
+                "sp_used": sp_needed,
+                "resulting_hp": calculate_champions_hp(
+                    base_stats["hp"], sp_needed, level
+                ),
+            })
+
+        elif isinstance(goal, MaximizeGoal):
+            stat = goal.stat
+            sp_to_add = min(
+                MAX_SP_PER_STAT - sp_spread[stat], remaining
+            )
+            sp_spread[stat] += sp_to_add
+            remaining -= sp_to_add
+            goal_results.append({
+                "goal": f"Maximize {stat}",
+                "achieved": True,
+                "sp_used": sp_to_add,
+            })
+
+    return {
+        "success": True,
+        "sp_spread": sp_spread,
+        "remaining_sp": remaining,
+        "total_sp": MAX_TOTAL_SP - remaining,
+        "goal_results": goal_results,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_champions_sp_optimizer.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Lint check**
+
+Run: `uv run ruff check src/smogon_vgc_mcp/calculator/champions_sp_optimizer.py tests/test_champions_sp_optimizer.py && uv run ruff format --check src/smogon_vgc_mcp/calculator/champions_sp_optimizer.py tests/test_champions_sp_optimizer.py`
+Expected: Clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/calculator/champions_sp_optimizer.py tests/test_champions_sp_optimizer.py
+git commit -m "feat: add Champions SP optimizer with HP thresholds and speed goals"
+```
+
+---
+
+### Task 4: Champions Calculator MCP Tools
+
+**Files:**
+- Create: `src/smogon_vgc_mcp/tools/champions_calculator.py`
+- Modify: `src/smogon_vgc_mcp/tools/__init__.py`
+- Modify: `src/smogon_vgc_mcp/server.py`
+- Create: `tests/test_champions_calculator_tools.py`
+
+- [ ] **Step 1: Write failing tests for MCP tool registration**
+
+```python
+"""Tests for Champions calculator MCP tools."""
+
+import pytest
+
+from mcp.server.fastmcp import FastMCP
+
+from smogon_vgc_mcp.tools.champions_calculator import (
+    register_champions_calculator_tools,
+)
+
+
+@pytest.fixture
+def mcp_server():
+    """Create a test MCP server."""
+    return FastMCP("test")
+
+
+class TestChampionsCalculatorToolRegistration:
+    """Tests that Champions tools register correctly."""
+
+    def test_tools_register_without_error(self, mcp_server):
+        register_champions_calculator_tools(mcp_server)
+
+    def test_calculate_champions_stats_tool(self, mcp_server):
+        register_champions_calculator_tools(mcp_server)
+        tools = mcp_server._tool_manager._tools
+        assert "calculate_champions_stats" in tools
+
+    def test_compare_champions_speeds_tool(self, mcp_server):
+        register_champions_calculator_tools(mcp_server)
+        tools = mcp_server._tool_manager._tools
+        assert "compare_champions_speeds" in tools
+
+    def test_get_champions_speed_benchmarks_tool(self, mcp_server):
+        register_champions_calculator_tools(mcp_server)
+        tools = mcp_server._tool_manager._tools
+        assert "get_champions_speed_benchmarks" in tools
+
+    def test_suggest_champions_sp_spread_tool(self, mcp_server):
+        register_champions_calculator_tools(mcp_server)
+        tools = mcp_server._tool_manager._tools
+        assert "suggest_champions_sp_spread" in tools
+
+
+class TestCalculateChampionsStatsTool:
+    """Integration tests for calculate_champions_stats tool."""
+
+    @pytest.mark.asyncio
+    async def test_valid_pokemon_returns_stats(self, mcp_server):
+        register_champions_calculator_tools(mcp_server)
+        tool_fn = mcp_server._tool_manager._tools[
+            "calculate_champions_stats"
+        ].fn
+        result = await tool_fn(
+            pokemon="venusaur",
+            sp_spread="0/0/0/32/0/2",
+            nature="Modest",
+        )
+        assert "calculated_stats" in result
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_pokemon_returns_error(self, mcp_server):
+        register_champions_calculator_tools(mcp_server)
+        tool_fn = mcp_server._tool_manager._tools[
+            "calculate_champions_stats"
+        ].fn
+        result = await tool_fn(
+            pokemon="notapokemon",
+            sp_spread="0/0/0/0/0/0",
+            nature="Hardy",
+        )
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_sp_over_66_returns_error(self, mcp_server):
+        register_champions_calculator_tools(mcp_server)
+        tool_fn = mcp_server._tool_manager._tools[
+            "calculate_champions_stats"
+        ].fn
+        result = await tool_fn(
+            pokemon="venusaur",
+            sp_spread="32/32/32/0/0/0",
+            nature="Hardy",
+        )
+        assert "error" in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_champions_calculator_tools.py -v`
+Expected: FAIL with `ImportError`
+
+- [ ] **Step 3: Implement `champions_calculator.py` MCP tools**
+
+```python
+"""Champions calculator tools for MCP server.
+
+Separate tool module for Pokemon Champions format calculations.
+Uses Stat Points (SP) instead of EVs/IVs.
+"""
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from smogon_vgc_mcp.calculator.champions_speed import (
+    compare_champions_speeds as _compare_speeds,
+    find_champions_speed_benchmarks,
+    find_champions_speed_sp,
+    get_champions_speed,
+)
+from smogon_vgc_mcp.calculator.champions_sp_optimizer import (
+    HpThresholdGoal,
+    MaximizeGoal,
+    SpeedGoal,
+    optimize_champions_sp,
+)
+from smogon_vgc_mcp.calculator.champions_stats import (
+    MAX_SP_PER_STAT,
+    MAX_TOTAL_SP,
+    STAT_ORDER,
+    calculate_all_champions_stats,
+    format_champions_stats,
+)
+from smogon_vgc_mcp.database.models import ChampionsDexPokemon
+from smogon_vgc_mcp.database.queries import get_champions_pokemon
+from smogon_vgc_mcp.utils import make_error_response
+
+
+def _parse_sp_spread(sp_string: str) -> dict[str, int] | str:
+    """Parse SP spread string 'HP/Atk/Def/SpA/SpD/Spe' into dict.
+
+    Returns dict on success, error string on failure.
+    """
+    parts = sp_string.split("/")
+    if len(parts) != 6:
+        return "SP spread must be 6 values separated by / (e.g., '0/0/0/32/0/2')"
+
+    try:
+        values = [int(p.strip()) for p in parts]
+    except ValueError:
+        return "SP values must be integers"
+
+    for i, v in enumerate(values):
+        if not 0 <= v <= MAX_SP_PER_STAT:
+            return (
+                f"{STAT_ORDER[i]} SP must be 0-{MAX_SP_PER_STAT}, got {v}"
+            )
+
+    total = sum(values)
+    if total > MAX_TOTAL_SP:
+        return f"Total SP must not exceed {MAX_TOTAL_SP}, got {total}"
+
+    return dict(zip(STAT_ORDER, values))
+
+
+async def _get_champions_base_stats(
+    pokemon_id: str,
+) -> ChampionsDexPokemon | None:
+    """Look up Champions Pokemon base stats from database."""
+    return await get_champions_pokemon(pokemon_id)
+
+
+def register_champions_calculator_tools(mcp: FastMCP) -> None:
+    """Register Champions calculator tools with the MCP server."""
+
+    @mcp.tool()
+    async def calculate_champions_stats(
+        pokemon: str,
+        sp_spread: str,
+        nature: str = "Hardy",
+        level: int = 50,
+    ) -> dict:
+        """Calculate exact stat values for a Champions format Pokemon.
+
+        Champions uses Stat Points (SP) instead of EVs/IVs.
+        66 total SP, max 32 per stat.
+
+        Returns: pokemon, level, nature, sp_spread, base_stats,
+        calculated_stats, formatted.
+
+        Examples:
+        - "What are Venusaur's stats with 32 SpA and Modest?"
+        - "Calculate Incineroar's bulk with 32 HP / 32 Def"
+
+        Args:
+            pokemon: Pokemon name (e.g., "venusaur", "incineroar").
+            sp_spread: SP allocation "HP/Atk/Def/SpA/SpD/Spe"
+                       (e.g., "0/0/0/32/0/2"). Max 32 each, 66 total.
+            nature: Nature name (e.g., "Modest", "Adamant"). Default neutral.
+            level: Pokemon level. Default 50.
+        """
+        sp = _parse_sp_spread(sp_spread)
+        if isinstance(sp, str):
+            return make_error_response(sp)
+
+        pokemon_data = await _get_champions_base_stats(
+            pokemon.lower().replace(" ", "").replace("-", "")
+        )
+        if not pokemon_data:
+            return make_error_response(
+                f"Pokemon '{pokemon}' not found in Champions dex",
+                hint="Check spelling or use the Champions dex name",
+            )
+
+        stats = calculate_all_champions_stats(
+            pokemon_data.base_stats, sp, nature, level
+        )
+        if stats is None:
+            return make_error_response(
+                f"Invalid nature '{nature}'",
+                hint="Use a valid nature like Adamant, Modest, Jolly, etc.",
+            )
+
+        return {
+            "pokemon": pokemon_data.name,
+            "level": level,
+            "nature": nature,
+            "sp_spread": sp_spread,
+            "base_stats": pokemon_data.base_stats,
+            "calculated_stats": stats,
+            "formatted": format_champions_stats(stats),
+        }
+
+    @mcp.tool()
+    async def compare_champions_speeds(
+        pokemon1: str,
+        sp1: int,
+        nature1: str,
+        pokemon2: str,
+        sp2: int,
+        nature2: str,
+    ) -> dict:
+        """Compare speed between two Champions Pokemon builds.
+
+        Returns: pokemon1 {name, speed}, pokemon2 {name, speed},
+        result, difference.
+
+        Args:
+            pokemon1: First Pokemon name.
+            sp1: First Pokemon's Speed SP (0-32).
+            nature1: First Pokemon's nature.
+            pokemon2: Second Pokemon name.
+            sp2: Second Pokemon's Speed SP (0-32).
+            nature2: Second Pokemon's nature.
+        """
+        p1 = await _get_champions_base_stats(
+            pokemon1.lower().replace(" ", "").replace("-", "")
+        )
+        p2 = await _get_champions_base_stats(
+            pokemon2.lower().replace(" ", "").replace("-", "")
+        )
+
+        if not p1:
+            return make_error_response(
+                f"Pokemon '{pokemon1}' not found in Champions dex"
+            )
+        if not p2:
+            return make_error_response(
+                f"Pokemon '{pokemon2}' not found in Champions dex"
+            )
+
+        return _compare_speeds(
+            pokemon1=p1.name,
+            base_spe1=p1.base_stats["spe"],
+            sp1=sp1,
+            nature1=nature1,
+            pokemon2=p2.name,
+            base_spe2=p2.base_stats["spe"],
+            sp2=sp2,
+            nature2=nature2,
+        )
+
+    @mcp.tool()
+    async def get_champions_speed_benchmarks(
+        pokemon: str,
+        sp: int = 0,
+        nature: str = "Hardy",
+    ) -> dict:
+        """Find what Champions meta Pokemon a speed stat outspeeds.
+
+        Uses pre-computed Champions speed tier data including
+        weather abilities, Tailwind, and boost benchmarks.
+
+        Returns: pokemon, speed, outspeeds[], underspeeds[], speed_ties[].
+
+        Args:
+            pokemon: Pokemon name.
+            sp: Speed SP investment (0-32).
+            nature: Nature (e.g., "Jolly" for +Spe, "Brave" for -Spe).
+        """
+        p = await _get_champions_base_stats(
+            pokemon.lower().replace(" ", "").replace("-", "")
+        )
+        if not p:
+            return make_error_response(
+                f"Pokemon '{pokemon}' not found in Champions dex"
+            )
+
+        speed = get_champions_speed(
+            p.base_stats["spe"], sp, nature
+        )
+        return find_champions_speed_benchmarks(p.name, speed)
+
+    @mcp.tool()
+    async def suggest_champions_sp_spread(
+        pokemon: str,
+        nature: str,
+        goals: list[dict[str, Any]],
+        item: str | None = None,
+    ) -> dict:
+        """Generate an optimized SP spread for a Champions Pokemon.
+
+        Allocates 66 total Stat Points based on prioritized goals.
+        Goals are processed in order (first = highest priority).
+
+        Returns: pokemon, sp_spread, remaining_sp, goal_results[],
+        calculated_stats.
+
+        Goal types:
+        - SPEED: {"type": "speed", "target_speed": int}
+          Optional: mode ("outspeed" or "underspeed", default "outspeed")
+        - HP: {"type": "hp", "item": str}
+          Optimizes HP for Leftovers/Life Orb/Sitrus Berry
+        - MAXIMIZE: {"type": "maximize", "stat": str}
+          Dumps remaining SP into stat
+
+        Examples:
+        - "Build Venusaur to outspeed 132 speed tier, then max SpA"
+        - "Optimize Incineroar for Leftovers HP, then max SpD"
+
+        Args:
+            pokemon: Pokemon name.
+            nature: Nature name.
+            goals: List of goal dicts in priority order.
+            item: Held item (used for HP optimization).
+        """
+        p = await _get_champions_base_stats(
+            pokemon.lower().replace(" ", "").replace("-", "")
+        )
+        if not p:
+            return make_error_response(
+                f"Pokemon '{pokemon}' not found in Champions dex"
+            )
+
+        parsed_goals = []
+        for g in goals:
+            goal_type = g.get("type", "").lower()
+            if goal_type == "speed":
+                parsed_goals.append(SpeedGoal(
+                    target_speed=g.get("target_speed", 0),
+                    mode=g.get("mode", "outspeed"),
+                ))
+            elif goal_type == "hp":
+                parsed_goals.append(HpThresholdGoal(
+                    item=g.get("item", item or ""),
+                ))
+            elif goal_type == "maximize":
+                parsed_goals.append(MaximizeGoal(
+                    stat=g.get("stat", "hp"),
+                ))
+
+        if not parsed_goals:
+            return make_error_response(
+                "No valid goals provided",
+                hint="Goals need 'type' field: speed, hp, or maximize",
+            )
+
+        result = optimize_champions_sp(
+            base_stats=p.base_stats,
+            nature=nature,
+            goals=parsed_goals,
+        )
+
+        # Calculate final stats
+        if result["success"]:
+            stats = calculate_all_champions_stats(
+                p.base_stats, result["sp_spread"], nature
+            )
+            result["calculated_stats"] = stats
+            if stats:
+                result["formatted"] = format_champions_stats(stats)
+
+        sp_str = "/".join(
+            str(result["sp_spread"][s]) for s in STAT_ORDER
+        )
+        result["pokemon"] = p.name
+        result["sp_spread_formatted"] = sp_str
+
+        return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_champions_calculator_tools.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Update `tools/__init__.py` to export new registration function**
+
+Add to `src/smogon_vgc_mcp/tools/__init__.py`:
+
+```python
+from smogon_vgc_mcp.tools.champions_calculator import register_champions_calculator_tools
+```
+
+And add `"register_champions_calculator_tools"` to the `__all__` list.
+
+- [ ] **Step 6: Register Champions tools in `server.py`**
+
+Add to `src/smogon_vgc_mcp/server.py`:
+
+```python
+from smogon_vgc_mcp.tools import register_champions_calculator_tools
+```
+
+And call `register_champions_calculator_tools(logged_mcp)` after the other tool registrations.
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `uv run python -m pytest -v`
+Expected: All tests PASS
+
+- [ ] **Step 8: Lint check**
+
+Run: `uv run ruff check src/smogon_vgc_mcp/tools/champions_calculator.py tests/test_champions_calculator_tools.py && uv run ruff format --check src/smogon_vgc_mcp/tools/champions_calculator.py tests/test_champions_calculator_tools.py`
+Expected: Clean
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/tools/champions_calculator.py src/smogon_vgc_mcp/tools/__init__.py src/smogon_vgc_mcp/server.py tests/test_champions_calculator_tools.py
+git commit -m "feat: add Champions calculator MCP tools (stats, speed, SP optimizer)"
+```
+
+---
+
+### Task 5: Final Integration — Run Full Suite & Verify
+
+**Files:**
+- None new; verification only
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `uv run python -m pytest -v --tb=short`
+Expected: All tests PASS (existing 131 + new ~50)
+
+- [ ] **Step 2: Type check**
+
+Run: `uv run ty check`
+Expected: Clean (or only pre-existing warnings)
+
+- [ ] **Step 3: Lint full project**
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+Expected: Clean
+
+- [ ] **Step 4: Verify Champions tools are registered**
+
+Run: `uv run python -c "from smogon_vgc_mcp.tools.champions_calculator import register_champions_calculator_tools; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 5: Final commit if any fixes needed**
+
+Only if Steps 1-4 required changes:
+```bash
+git add -A
+git commit -m "fix: resolve integration issues from Champions calculator"
+```

--- a/docs/superpowers/plans/2026-04-10-champions-data-pipelines.md
+++ b/docs/superpowers/plans/2026-04-10-champions-data-pipelines.md
@@ -1,0 +1,1726 @@
+# Champions Data Pipelines Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build two Champions-format data pipelines: a Serebii scraper for move changes (new/rebalanced moves) and a Pikalytics scraper for usage statistics (moves, items, abilities, teammates, spreads per Pokemon across ELO cutoffs).
+
+**Architecture:** Follow the existing `fetcher/champions_dex.py` two-phase pattern (fetch-all → transactional store). Serebii move scraper reuses the existing `champions_dex_moves` schema/`ChampionsDexMove` model. Pikalytics needs a new `champions_usage` schema (snapshot + per-pokemon rows + distribution rows) modeled on the existing `pokemon_usage` tables but keyed on ELO cutoff ("0+", "1500+", "1630+", "1760+") instead of month. Parsers extract JSON-LD Dataset schema blocks from SSR HTML. Both pipelines wire into `fetch_text_resilient()` with the existing `serebii` / new `pikalytics` circuit breaker.
+
+**Tech Stack:** Python 3.12, aiosqlite, BeautifulSoup4, stdlib `json`, `fetch_text_resilient`, pytest/pytest-asyncio, uv+ruff+ty.
+
+---
+
+## File Structure
+
+### Phase 1 — Serebii Champions moves
+
+- Create: `src/smogon_vgc_mcp/fetcher/champions_moves.py` — parser + fetch/store for `https://www.serebii.net/pokemonchampions/updatedattacks.shtml`
+- Create: `tests/fixtures/serebii_champions_moves.html` — real HTML fixture for offline parser tests
+- Create: `tests/test_fetcher_champions_moves.py` — parser + store tests
+- Modify: `src/smogon_vgc_mcp/database/queries.py` — add `get_champions_move(move_id)` and `list_champions_moves()` helpers
+
+### Phase 2 — Pikalytics Champions usage
+
+- Modify: `src/smogon_vgc_mcp/database/schema.py` — add `champions_usage_snapshots`, `champions_pokemon_usage`, `champions_usage_moves`, `champions_usage_items`, `champions_usage_abilities`, `champions_usage_teammates`, `champions_usage_spreads` tables + indexes
+- Modify: `src/smogon_vgc_mcp/database/models.py` — add `ChampionsUsageSnapshot`, `ChampionsPokemonUsage`, distribution row dataclasses
+- Create: `src/smogon_vgc_mcp/fetcher/pikalytics_champions.py` — HTML + JSON-LD parser, fetch orchestrator, transactional store
+- Create: `tests/fixtures/pikalytics_incineroar.html` — real fixture for parser tests
+- Create: `tests/test_fetcher_pikalytics_champions.py` — parser + store tests
+- Modify: `src/smogon_vgc_mcp/database/queries.py` — add `get_champions_usage(pokemon, elo)`, `list_champions_usage_snapshots()`
+- Create: `src/smogon_vgc_mcp/tools/champions_usage.py` — MCP tool `get_champions_usage_stats(pokemon, elo="0+")`
+- Modify: `src/smogon_vgc_mcp/tools/__init__.py` — export + register
+- Modify: `src/smogon_vgc_mcp/server.py` — register tool
+- Create: `tests/test_tools_champions_usage.py` — MCP tool tests
+
+---
+
+# Phase 1: Serebii Champions Moves Scraper
+
+The Serebii page lists "Updated Attacks" — moves whose stats/behavior differ from mainline. Schema (`champions_dex_moves`) and model (`ChampionsDexMove`) already exist, so this phase is parser + fetch glue.
+
+## Task 1: Capture Serebii moves fixture and write parser
+
+**Files:**
+- Create: `tests/fixtures/serebii_champions_moves.html`
+- Create: `src/smogon_vgc_mcp/fetcher/champions_moves.py`
+- Create: `tests/test_fetcher_champions_moves.py`
+
+- [ ] **Step 1: Capture the HTML fixture**
+
+Fetch the page once manually and save to the fixture path. From repo root:
+
+```bash
+curl -sSL -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36" \
+  "https://www.serebii.net/pokemonchampions/updatedattacks.shtml" \
+  > tests/fixtures/serebii_champions_moves.html
+```
+
+Expected: file size >10KB, contains `<table class="dextable">` tags.
+Sanity-check:
+
+```bash
+wc -c tests/fixtures/serebii_champions_moves.html
+grep -c 'dextable' tests/fixtures/serebii_champions_moves.html
+```
+
+Expected: size > 10000, at least 1 dextable match.
+
+- [ ] **Step 2: Write failing parser test (single move)**
+
+Create `tests/test_fetcher_champions_moves.py`:
+
+```python
+"""Tests for Serebii Champions move changes scraper."""
+
+from pathlib import Path
+
+import pytest
+
+from smogon_vgc_mcp.fetcher.champions_moves import parse_serebii_moves_page
+
+FIXTURE = Path(__file__).parent / "fixtures" / "serebii_champions_moves.html"
+
+
+@pytest.fixture
+def fixture_html() -> str:
+    return FIXTURE.read_text(encoding="latin-1")
+
+
+def test_parse_returns_list_of_moves(fixture_html: str) -> None:
+    moves = parse_serebii_moves_page(fixture_html)
+    assert isinstance(moves, list)
+    assert len(moves) > 0
+
+
+def test_parsed_moves_have_required_fields(fixture_html: str) -> None:
+    moves = parse_serebii_moves_page(fixture_html)
+    for m in moves:
+        assert m["id"]
+        assert m["name"]
+        assert m["type"]
+        assert m["category"] in ("Physical", "Special", "Status")
+        # base_power/accuracy may be None for status/variable moves
+        assert "base_power" in m
+        assert "accuracy" in m
+        assert "pp" in m
+
+
+def test_parse_handles_empty_html() -> None:
+    assert parse_serebii_moves_page("") == []
+    assert parse_serebii_moves_page("<html></html>") == []
+```
+
+- [ ] **Step 3: Run tests, expect import error**
+
+```bash
+uv run python -m pytest tests/test_fetcher_champions_moves.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'smogon_vgc_mcp.fetcher.champions_moves'`.
+
+- [ ] **Step 4: Implement minimal parser**
+
+Create `src/smogon_vgc_mcp/fetcher/champions_moves.py`:
+
+```python
+"""Parse Pokemon Champions move changes from Serebii.
+
+Source: https://www.serebii.net/pokemonchampions/updatedattacks.shtml
+Each move is rendered in a dextable with columns for name, type, category,
+power, accuracy, PP, and effect description.
+"""
+
+from __future__ import annotations
+
+import re
+
+from bs4 import BeautifulSoup, Tag
+
+_CATEGORY_MAP = {
+    "physical": "Physical",
+    "special": "Special",
+    "status": "Status",
+    "other": "Status",
+}
+
+
+def _slugify_move(name: str) -> str:
+    """Convert 'Dragon Claw' -> 'dragonclaw' (matches Showdown id convention)."""
+    return re.sub(r"[^a-z0-9]", "", name.lower())
+
+
+def _parse_int_or_none(text: str) -> int | None:
+    text = text.strip()
+    if not text or text in ("--", "—", "-"):
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def _extract_category_from_img(td: Tag) -> str | None:
+    """Category is rendered as an icon img; read its src or alt."""
+    img = td.find("img")
+    if not img:
+        text = td.get_text(strip=True).lower()
+        return _CATEGORY_MAP.get(text)
+    src = (img.get("src") or "").lower()
+    alt = (img.get("alt") or "").lower()
+    for key, val in _CATEGORY_MAP.items():
+        if key in src or key in alt:
+            return val
+    return None
+
+
+def _extract_type_from_img(td: Tag) -> str | None:
+    img = td.find("img")
+    if not img:
+        return td.get_text(strip=True).capitalize() or None
+    src = (img.get("src") or "").lower()
+    m = re.search(r"/type/([a-z]+)\.(?:gif|png)", src)
+    if m:
+        return m.group(1).capitalize()
+    alt = (img.get("alt") or "").strip()
+    alt = re.sub(r"-type$", "", alt, flags=re.I)
+    return alt.capitalize() or None
+
+
+def parse_serebii_moves_page(html: str) -> list[dict]:
+    """Parse the Serebii updated attacks page into a list of move dicts.
+
+    Each dict has keys: id, name, type, category, base_power, accuracy, pp,
+    priority, target, description, short_desc. Unknown fields are None.
+    """
+    if not html or len(html.strip()) < 100:
+        return []
+
+    soup = BeautifulSoup(html, "html.parser")
+    moves: list[dict] = []
+
+    for table in soup.find_all("table", class_="dextable"):
+        move = _parse_move_table(table)
+        if move is not None:
+            moves.append(move)
+
+    return moves
+
+
+def _parse_move_table(table: Tag) -> dict | None:
+    """Parse one dextable. Each move table has a header row with the name,
+    followed by a stats row (type, category, power, accuracy, PP) and a
+    description row."""
+    # Name is typically in the first <td class="fooevo"> or <h3>
+    name_td = table.find("td", class_="fooevo")
+    if name_td is None:
+        h3 = table.find("h3")
+        name = h3.get_text(strip=True) if h3 else ""
+    else:
+        name = name_td.get_text(strip=True)
+
+    if not name:
+        return None
+
+    # Stats row: look for a row of <td class="fooinfo"> cells
+    stat_rows = [
+        tr for tr in table.find_all("tr") if tr.find_all("td", class_="fooinfo")
+    ]
+    if not stat_rows:
+        return None
+
+    type_name: str | None = None
+    category: str | None = None
+    power: int | None = None
+    accuracy: int | None = None
+    pp: int | None = None
+
+    # Expect one row with 5 fooinfo cells: type | category | power | accuracy | PP
+    for row in stat_rows:
+        cells = row.find_all("td", class_="fooinfo")
+        if len(cells) >= 5:
+            type_name = _extract_type_from_img(cells[0])
+            category = _extract_category_from_img(cells[1])
+            power = _parse_int_or_none(cells[2].get_text())
+            accuracy = _parse_int_or_none(cells[3].get_text())
+            pp = _parse_int_or_none(cells[4].get_text())
+            break
+
+    if type_name is None or category is None:
+        return None
+
+    # Description: last fooinfo row that spans full width
+    description = ""
+    for row in stat_rows:
+        cells = row.find_all("td", class_="fooinfo")
+        if len(cells) == 1:
+            txt = cells[0].get_text(" ", strip=True)
+            if len(txt) > len(description):
+                description = txt
+
+    return {
+        "id": _slugify_move(name),
+        "name": name,
+        "type": type_name,
+        "category": category,
+        "base_power": power,
+        "accuracy": accuracy,
+        "pp": pp or 0,
+        "priority": 0,
+        "target": None,
+        "description": description or None,
+        "short_desc": description or None,
+    }
+```
+
+- [ ] **Step 5: Run tests, expect some to pass**
+
+```bash
+uv run python -m pytest tests/test_fetcher_champions_moves.py -v
+```
+
+Expected: `test_parse_handles_empty_html` passes. `test_parse_returns_list_of_moves` and `test_parsed_moves_have_required_fields` should pass if the real HTML matches the assumed `dextable` / `fooinfo` layout. If they fail, inspect the fixture:
+
+```bash
+uv run python -c "
+from pathlib import Path
+from bs4 import BeautifulSoup
+html = Path('tests/fixtures/serebii_champions_moves.html').read_text(encoding='latin-1')
+soup = BeautifulSoup(html, 'html.parser')
+tables = soup.find_all('table', class_='dextable')
+print(f'dextables: {len(tables)}')
+if tables:
+    print(tables[0].prettify()[:2000])
+"
+```
+
+Then adjust `_parse_move_table` to match the actual structure (column order, class names, wrapper tags). Re-run until both tests pass.
+
+- [ ] **Step 6: Commit Phase 1 parser**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/champions_moves.py \
+        tests/test_fetcher_champions_moves.py \
+        tests/fixtures/serebii_champions_moves.html
+git commit -m "feat(champions): add Serebii move changes parser"
+```
+
+---
+
+## Task 2: Fetch + store orchestrator for Champions moves
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/fetcher/champions_moves.py`
+- Modify: `tests/test_fetcher_champions_moves.py`
+- Modify: `src/smogon_vgc_mcp/database/queries.py`
+
+- [ ] **Step 1: Write failing store test**
+
+Append to `tests/test_fetcher_champions_moves.py`:
+
+```python
+import aiosqlite
+
+from smogon_vgc_mcp.database.schema import SCHEMA
+from smogon_vgc_mcp.fetcher.champions_moves import store_champions_moves
+
+
+@pytest.mark.asyncio
+async def test_store_inserts_moves() -> None:
+    moves = [
+        {
+            "id": "dragonclaw",
+            "name": "Dragon Claw",
+            "type": "Dragon",
+            "category": "Physical",
+            "base_power": 85,
+            "accuracy": 100,
+            "pp": 15,
+            "priority": 0,
+            "target": None,
+            "description": "A slashing attack with sharp claws.",
+            "short_desc": "A slashing attack with sharp claws.",
+        }
+    ]
+    async with aiosqlite.connect(":memory:") as db:
+        await db.executescript(SCHEMA)
+        count = await store_champions_moves(db, moves)
+        assert count == 1
+        async with db.execute(
+            "SELECT name, type, base_power FROM champions_dex_moves WHERE id = ?",
+            ("dragonclaw",),
+        ) as cursor:
+            row = await cursor.fetchone()
+    assert row == ("Dragon Claw", "Dragon", 85)
+
+
+@pytest.mark.asyncio
+async def test_store_replaces_existing() -> None:
+    async with aiosqlite.connect(":memory:") as db:
+        await db.executescript(SCHEMA)
+        await store_champions_moves(
+            db, [{"id": "x", "name": "X", "type": "Fire", "category": "Physical",
+                  "base_power": 50, "accuracy": 100, "pp": 10, "priority": 0,
+                  "target": None, "description": None, "short_desc": None}],
+        )
+        await store_champions_moves(
+            db, [{"id": "x", "name": "X", "type": "Fire", "category": "Physical",
+                  "base_power": 75, "accuracy": 100, "pp": 10, "priority": 0,
+                  "target": None, "description": None, "short_desc": None}],
+        )
+        async with db.execute(
+            "SELECT COUNT(*), MAX(base_power) FROM champions_dex_moves"
+        ) as cursor:
+            row = await cursor.fetchone()
+    assert row == (1, 75)
+```
+
+- [ ] **Step 2: Run tests, expect failure**
+
+```bash
+uv run python -m pytest tests/test_fetcher_champions_moves.py::test_store_inserts_moves -v
+```
+
+Expected: `ImportError: cannot import name 'store_champions_moves'`.
+
+- [ ] **Step 3: Implement store function**
+
+Append to `src/smogon_vgc_mcp/fetcher/champions_moves.py`:
+
+```python
+import asyncio
+from pathlib import Path
+
+import aiosqlite
+
+from smogon_vgc_mcp.database.schema import get_connection, get_db_path, init_database
+from smogon_vgc_mcp.resilience import get_all_circuit_states
+from smogon_vgc_mcp.utils import fetch_text_resilient
+
+SEREBII_MOVES_URL = "https://www.serebii.net/pokemonchampions/updatedattacks.shtml"
+
+
+async def store_champions_moves(
+    db: aiosqlite.Connection,
+    moves: list[dict],
+    *,
+    _commit: bool = True,
+) -> int:
+    """Replace all Champions moves with the provided list.
+
+    DELETE + INSERT OR REPLACE pattern matching store_champions_pokemon_data.
+    Returns count of stored rows.
+    """
+    await db.execute("DELETE FROM champions_dex_moves")
+    count = 0
+    for m in moves:
+        await db.execute(
+            """INSERT OR REPLACE INTO champions_dex_moves
+               (id, num, name, type, category, base_power, accuracy, pp,
+                priority, target, description, short_desc)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                m["id"],
+                m.get("num"),
+                m["name"],
+                m["type"],
+                m["category"],
+                m.get("base_power"),
+                m.get("accuracy"),
+                m.get("pp", 0),
+                m.get("priority", 0),
+                m.get("target"),
+                m.get("description"),
+                m.get("short_desc"),
+            ),
+        )
+        count += 1
+    if _commit:
+        await db.commit()
+    return count
+
+
+async def fetch_and_store_champions_moves(
+    db_path: Path | None = None,
+    *,
+    dry_run: bool = False,
+) -> dict:
+    """Fetch the Serebii updated attacks page and store parsed moves.
+
+    Returns dict: {fetched, stored, errors, circuit_states, dry_run}.
+    """
+    if db_path is None:
+        db_path = get_db_path()
+
+    await init_database(db_path)
+
+    result = await fetch_text_resilient(SEREBII_MOVES_URL, service="serebii")
+    errors: list[dict] = []
+    if not result.success or not result.data:
+        errors.append({"url": SEREBII_MOVES_URL, "message": "Fetch failed"})
+        return {
+            "fetched": 0,
+            "stored": 0,
+            "errors": errors,
+            "circuit_states": get_all_circuit_states(),
+            "dry_run": dry_run,
+        }
+
+    moves = parse_serebii_moves_page(result.data)
+
+    if dry_run:
+        return {
+            "fetched": len(moves),
+            "stored": 0,
+            "errors": errors,
+            "circuit_states": get_all_circuit_states(),
+            "dry_run": True,
+            "results": moves,
+        }
+
+    stored = 0
+    async with get_connection(db_path) as db:
+        try:
+            stored = await store_champions_moves(db, moves, _commit=False)
+            await db.commit()
+        except Exception as exc:
+            await db.rollback()
+            errors.append({"url": "store", "message": str(exc)})
+
+    return {
+        "fetched": len(moves),
+        "stored": stored,
+        "errors": errors,
+        "circuit_states": get_all_circuit_states(),
+        "dry_run": False,
+    }
+```
+
+- [ ] **Step 4: Run store tests**
+
+```bash
+uv run python -m pytest tests/test_fetcher_champions_moves.py -v
+```
+
+Expected: all tests pass. If not, inspect the error, re-read the fetcher file, and fix.
+
+- [ ] **Step 5: Add query helpers**
+
+In `src/smogon_vgc_mcp/database/queries.py`, find the existing Champions-related query functions (search for `champions_dex_pokemon`) and add alongside them:
+
+```python
+async def get_champions_move(move_id: str) -> ChampionsDexMove | None:
+    """Look up a single Champions move by normalized id (e.g. 'dragonclaw')."""
+    async with get_connection() as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            """SELECT id, num, name, type, category, base_power, accuracy,
+                      pp, priority, target, description, short_desc
+               FROM champions_dex_moves WHERE id = ?""",
+            (move_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+    if row is None:
+        return None
+    return ChampionsDexMove(
+        id=row["id"],
+        num=row["num"] or 0,
+        name=row["name"],
+        type=row["type"],
+        category=row["category"],
+        base_power=row["base_power"],
+        accuracy=row["accuracy"],
+        pp=row["pp"] or 0,
+        priority=row["priority"] or 0,
+        target=row["target"],
+        description=row["description"],
+        short_desc=row["short_desc"],
+    )
+
+
+async def list_champions_moves() -> list[ChampionsDexMove]:
+    """Return all Champions moves, ordered by name."""
+    async with get_connection() as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            """SELECT id, num, name, type, category, base_power, accuracy,
+                      pp, priority, target, description, short_desc
+               FROM champions_dex_moves ORDER BY name"""
+        ) as cursor:
+            rows = await cursor.fetchall()
+    return [
+        ChampionsDexMove(
+            id=r["id"],
+            num=r["num"] or 0,
+            name=r["name"],
+            type=r["type"],
+            category=r["category"],
+            base_power=r["base_power"],
+            accuracy=r["accuracy"],
+            pp=r["pp"] or 0,
+            priority=r["priority"] or 0,
+            target=r["target"],
+            description=r["description"],
+            short_desc=r["short_desc"],
+        )
+        for r in rows
+    ]
+```
+
+Ensure `ChampionsDexMove` is imported at the top of `queries.py` (check existing imports first — if only `ChampionsDexPokemon` is imported, add `ChampionsDexMove` to that line).
+
+- [ ] **Step 6: Type-check and lint**
+
+```bash
+uv run ty check src/smogon_vgc_mcp/fetcher/champions_moves.py \
+                src/smogon_vgc_mcp/database/queries.py
+uv run ruff check --fix src/smogon_vgc_mcp/fetcher/champions_moves.py \
+                       src/smogon_vgc_mcp/database/queries.py \
+                       tests/test_fetcher_champions_moves.py
+uv run ruff format src/smogon_vgc_mcp/fetcher/champions_moves.py \
+                   src/smogon_vgc_mcp/database/queries.py \
+                   tests/test_fetcher_champions_moves.py
+```
+
+Fix any reported errors. Re-run tests after.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/champions_moves.py \
+        src/smogon_vgc_mcp/database/queries.py \
+        tests/test_fetcher_champions_moves.py
+git commit -m "feat(champions): store Serebii move changes + query helpers"
+```
+
+---
+
+# Phase 2: Pikalytics Champions Usage Scraper
+
+Pikalytics URL pattern: `https://www.pikalytics.com/pokedex/championspreview/<pokemon_slug>`. Each page is server-rendered HTML that includes a JSON-LD `Dataset` schema block alongside static sections listing usage %, moves, abilities, items, teammates, and spreads. ELO cutoffs are "0+", "1500+", "1630+", "1760+" and each cutoff is selectable on the page (we scrape each cutoff separately and tag rows with the cutoff).
+
+## Task 3: Add Champions usage schema and models
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/database/schema.py`
+- Modify: `src/smogon_vgc_mcp/database/models.py`
+- Create: `tests/test_database_champions_usage_schema.py`
+
+- [ ] **Step 1: Write failing schema test**
+
+Create `tests/test_database_champions_usage_schema.py`:
+
+```python
+"""Tests that champions_usage tables exist with expected columns."""
+
+import aiosqlite
+import pytest
+
+from smogon_vgc_mcp.database.schema import SCHEMA
+
+EXPECTED_TABLES = {
+    "champions_usage_snapshots",
+    "champions_pokemon_usage",
+    "champions_usage_moves",
+    "champions_usage_items",
+    "champions_usage_abilities",
+    "champions_usage_teammates",
+    "champions_usage_spreads",
+}
+
+
+@pytest.mark.asyncio
+async def test_champions_usage_tables_exist() -> None:
+    async with aiosqlite.connect(":memory:") as db:
+        await db.executescript(SCHEMA)
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ) as cursor:
+            names = {row[0] async for row in cursor}
+    assert EXPECTED_TABLES <= names
+
+
+@pytest.mark.asyncio
+async def test_champions_pokemon_usage_columns() -> None:
+    async with aiosqlite.connect(":memory:") as db:
+        await db.executescript(SCHEMA)
+        async with db.execute(
+            "PRAGMA table_info(champions_pokemon_usage)"
+        ) as cursor:
+            cols = {row[1] async for row in cursor}
+    assert {"id", "snapshot_id", "pokemon", "usage_percent", "rank"} <= cols
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+```bash
+uv run python -m pytest tests/test_database_champions_usage_schema.py -v
+```
+
+Expected: assertion failures (tables missing).
+
+- [ ] **Step 3: Extend schema**
+
+In `src/smogon_vgc_mcp/database/schema.py`, append these CREATE TABLE statements to the `SCHEMA` string (before the closing `"""`):
+
+```sql
+-- =============================================================================
+-- Champions usage data (from Pikalytics)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS champions_usage_snapshots (
+    id INTEGER PRIMARY KEY,
+    elo_cutoff TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'pikalytics',
+    fetched_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(source, elo_cutoff)
+);
+
+CREATE TABLE IF NOT EXISTS champions_pokemon_usage (
+    id INTEGER PRIMARY KEY,
+    snapshot_id INTEGER REFERENCES champions_usage_snapshots(id) ON DELETE CASCADE,
+    pokemon TEXT NOT NULL,
+    usage_percent REAL,
+    rank INTEGER,
+    raw_count INTEGER,
+    UNIQUE(snapshot_id, pokemon)
+);
+
+CREATE TABLE IF NOT EXISTS champions_usage_moves (
+    id INTEGER PRIMARY KEY,
+    pokemon_usage_id INTEGER REFERENCES champions_pokemon_usage(id) ON DELETE CASCADE,
+    move TEXT NOT NULL,
+    percent REAL
+);
+
+CREATE TABLE IF NOT EXISTS champions_usage_items (
+    id INTEGER PRIMARY KEY,
+    pokemon_usage_id INTEGER REFERENCES champions_pokemon_usage(id) ON DELETE CASCADE,
+    item TEXT NOT NULL,
+    percent REAL
+);
+
+CREATE TABLE IF NOT EXISTS champions_usage_abilities (
+    id INTEGER PRIMARY KEY,
+    pokemon_usage_id INTEGER REFERENCES champions_pokemon_usage(id) ON DELETE CASCADE,
+    ability TEXT NOT NULL,
+    percent REAL
+);
+
+CREATE TABLE IF NOT EXISTS champions_usage_teammates (
+    id INTEGER PRIMARY KEY,
+    pokemon_usage_id INTEGER REFERENCES champions_pokemon_usage(id) ON DELETE CASCADE,
+    teammate TEXT NOT NULL,
+    percent REAL
+);
+
+CREATE TABLE IF NOT EXISTS champions_usage_spreads (
+    id INTEGER PRIMARY KEY,
+    pokemon_usage_id INTEGER REFERENCES champions_pokemon_usage(id) ON DELETE CASCADE,
+    nature TEXT,
+    hp INTEGER,
+    atk INTEGER,
+    def INTEGER,
+    spa INTEGER,
+    spd INTEGER,
+    spe INTEGER,
+    percent REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_champ_usage_snap_elo
+    ON champions_usage_snapshots(elo_cutoff);
+CREATE INDEX IF NOT EXISTS idx_champ_pokemon_usage_name
+    ON champions_pokemon_usage(pokemon);
+CREATE INDEX IF NOT EXISTS idx_champ_pokemon_usage_snap
+    ON champions_pokemon_usage(snapshot_id);
+```
+
+- [ ] **Step 4: Run schema test, expect pass**
+
+```bash
+uv run python -m pytest tests/test_database_champions_usage_schema.py -v
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 5: Add dataclass models**
+
+In `src/smogon_vgc_mcp/database/models.py`, append after the existing `ChampionsDexMove` class:
+
+```python
+@dataclass
+class ChampionsUsageSnapshot:
+    """A single Pikalytics Champions usage snapshot for one ELO cutoff."""
+
+    id: int
+    elo_cutoff: str  # "0+", "1500+", "1630+", "1760+"
+    source: str = "pikalytics"
+    fetched_at: str | None = None
+
+
+@dataclass
+class ChampionsPokemonUsage:
+    """Per-Pokemon usage row for a Champions snapshot."""
+
+    pokemon: str
+    usage_percent: float | None = None
+    rank: int | None = None
+    raw_count: int | None = None
+    moves: list[tuple[str, float]] = field(default_factory=list)
+    items: list[tuple[str, float]] = field(default_factory=list)
+    abilities: list[tuple[str, float]] = field(default_factory=list)
+    teammates: list[tuple[str, float]] = field(default_factory=list)
+    spreads: list[dict] = field(default_factory=list)
+```
+
+If `field` is not yet imported from `dataclasses` at the top of the file, update the import to `from dataclasses import dataclass, field`.
+
+- [ ] **Step 6: Type-check and commit**
+
+```bash
+uv run ty check src/smogon_vgc_mcp/database/
+uv run ruff check --fix src/smogon_vgc_mcp/database/ tests/test_database_champions_usage_schema.py
+uv run ruff format src/smogon_vgc_mcp/database/ tests/test_database_champions_usage_schema.py
+uv run python -m pytest tests/test_database_champions_usage_schema.py -v
+```
+
+All green, then:
+
+```bash
+git add src/smogon_vgc_mcp/database/schema.py \
+        src/smogon_vgc_mcp/database/models.py \
+        tests/test_database_champions_usage_schema.py
+git commit -m "feat(champions): add Pikalytics usage schema and models"
+```
+
+---
+
+## Task 4: Capture Pikalytics fixture and write parser
+
+**Files:**
+- Create: `tests/fixtures/pikalytics_incineroar.html`
+- Create: `src/smogon_vgc_mcp/fetcher/pikalytics_champions.py`
+- Create: `tests/test_fetcher_pikalytics_champions.py`
+
+- [ ] **Step 1: Capture the fixture**
+
+```bash
+curl -sSL -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36" \
+  "https://www.pikalytics.com/pokedex/championspreview/incineroar" \
+  > tests/fixtures/pikalytics_incineroar.html
+wc -c tests/fixtures/pikalytics_incineroar.html
+grep -c 'application/ld+json' tests/fixtures/pikalytics_incineroar.html
+```
+
+Expected: size > 20000, at least one `application/ld+json` match.
+
+- [ ] **Step 2: Write failing parser tests**
+
+Create `tests/test_fetcher_pikalytics_champions.py`:
+
+```python
+"""Tests for Pikalytics Champions usage parser."""
+
+from pathlib import Path
+
+import pytest
+
+from smogon_vgc_mcp.fetcher.pikalytics_champions import parse_pikalytics_page
+
+FIXTURE = Path(__file__).parent / "fixtures" / "pikalytics_incineroar.html"
+
+
+@pytest.fixture
+def html() -> str:
+    return FIXTURE.read_text(encoding="utf-8")
+
+
+def test_parse_returns_usage_dict(html: str) -> None:
+    result = parse_pikalytics_page(html, pokemon_slug="incineroar")
+    assert result is not None
+    assert result["pokemon"] == "incineroar"
+    assert "usage_percent" in result or "rank" in result
+
+
+def test_parse_extracts_moves(html: str) -> None:
+    result = parse_pikalytics_page(html, pokemon_slug="incineroar")
+    assert result is not None
+    assert isinstance(result["moves"], list)
+    assert len(result["moves"]) > 0
+    name, pct = result["moves"][0]
+    assert isinstance(name, str) and name
+    assert isinstance(pct, float)
+
+
+def test_parse_extracts_items_abilities_teammates(html: str) -> None:
+    result = parse_pikalytics_page(html, pokemon_slug="incineroar")
+    assert result is not None
+    assert isinstance(result["items"], list)
+    assert isinstance(result["abilities"], list)
+    assert isinstance(result["teammates"], list)
+
+
+def test_parse_handles_404() -> None:
+    assert parse_pikalytics_page("", pokemon_slug="missingno") is None
+    assert parse_pikalytics_page("<html>Not Found</html>", pokemon_slug="missingno") is None
+```
+
+- [ ] **Step 3: Run tests, expect import error**
+
+```bash
+uv run python -m pytest tests/test_fetcher_pikalytics_champions.py -v
+```
+
+Expected: `ModuleNotFoundError`.
+
+- [ ] **Step 4: Implement parser**
+
+Create `src/smogon_vgc_mcp/fetcher/pikalytics_champions.py`:
+
+```python
+"""Parse Pokemon Champions usage data from Pikalytics.
+
+URL pattern:
+  https://www.pikalytics.com/pokedex/championspreview/<pokemon_slug>
+
+Each page is server-rendered HTML and embeds a JSON-LD Dataset schema
+(<script type="application/ld+json">). We prefer JSON-LD where fields
+overlap, and fall back to parsing the visible percentage bars in the
+dedicated sections for moves/items/abilities/teammates/spreads.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from bs4 import BeautifulSoup, Tag
+
+_PERCENT_RE = re.compile(r"([\d.]+)\s*%")
+
+
+def _extract_json_ld(soup: BeautifulSoup) -> dict[str, Any] | None:
+    """Return the first JSON-LD block that looks like a Dataset."""
+    for script in soup.find_all("script", type="application/ld+json"):
+        try:
+            payload = json.loads(script.string or "{}")
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(payload, list):
+            for item in payload:
+                if isinstance(item, dict) and item.get("@type") == "Dataset":
+                    return item
+        elif isinstance(payload, dict) and payload.get("@type") == "Dataset":
+            return payload
+    return None
+
+
+def _parse_percent(text: str) -> float | None:
+    m = _PERCENT_RE.search(text)
+    if not m:
+        return None
+    try:
+        return float(m.group(1))
+    except ValueError:
+        return None
+
+
+def _section_rows(soup: BeautifulSoup, heading_keywords: list[str]) -> list[tuple[str, float]]:
+    """Find a section header whose text matches one of the keywords, then
+    return (label, percent) pairs from the immediately-following list items.
+
+    Pikalytics renders each stat section with a heading followed by a
+    <ul> or <div> of rows, each containing a label and a percent string.
+    """
+    results: list[tuple[str, float]] = []
+    for heading in soup.find_all(["h2", "h3", "h4", "div"]):
+        text = heading.get_text(" ", strip=True).lower()
+        if not any(kw in text for kw in heading_keywords):
+            continue
+
+        # Walk forward siblings until we find row-bearing content
+        container: Tag | None = None
+        for sib in heading.find_all_next():
+            if not isinstance(sib, Tag):
+                continue
+            if sib.name in ("ul", "ol"):
+                container = sib
+                break
+            # Some Pikalytics sections use div.stat-row patterns
+            if sib.name == "div" and sib.find(class_=re.compile(r"stat|row|bar", re.I)):
+                container = sib
+                break
+        if container is None:
+            continue
+
+        for row in container.find_all(["li", "div"], recursive=True):
+            row_text = row.get_text(" ", strip=True)
+            pct = _parse_percent(row_text)
+            if pct is None:
+                continue
+            label = _PERCENT_RE.sub("", row_text).strip(" -:")
+            if label:
+                results.append((label, pct))
+
+        if results:
+            break
+
+    return results
+
+
+def parse_pikalytics_page(html: str, pokemon_slug: str) -> dict[str, Any] | None:
+    """Parse a Pikalytics championspreview page into a usage dict.
+
+    Returns None for empty or 404-style pages. Returned dict has keys:
+      pokemon, usage_percent, rank, raw_count,
+      moves, items, abilities, teammates, spreads
+    """
+    if not html or len(html.strip()) < 200:
+        return None
+    if "Not Found" in html[:500] or "404" in html[:200]:
+        return None
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Prefer JSON-LD for high-confidence fields
+    ld = _extract_json_ld(soup) or {}
+    usage_percent: float | None = None
+    rank: int | None = None
+
+    # JSON-LD "variableMeasured" commonly holds summary stats
+    for var in ld.get("variableMeasured", []) if isinstance(ld.get("variableMeasured"), list) else []:
+        if not isinstance(var, dict):
+            continue
+        name = (var.get("name") or "").lower()
+        value = var.get("value")
+        if "usage" in name and value is not None:
+            try:
+                usage_percent = float(str(value).strip("%"))
+            except ValueError:
+                pass
+        elif "rank" in name and value is not None:
+            try:
+                rank = int(float(str(value)))
+            except ValueError:
+                pass
+
+    # Fallback: parse usage from headline like "Usage: 35.8%"
+    if usage_percent is None:
+        body = soup.get_text(" ", strip=True)
+        m = re.search(r"usage[^0-9%]*([\d.]+)\s*%", body, re.I)
+        if m:
+            try:
+                usage_percent = float(m.group(1))
+            except ValueError:
+                pass
+
+    moves = _section_rows(soup, ["move"])
+    items = _section_rows(soup, ["item"])
+    abilities = _section_rows(soup, ["abilit"])
+    teammates = _section_rows(soup, ["teammate", "partner"])
+
+    # Sanity check: if no signal at all, treat as 404
+    if usage_percent is None and not moves and not items and not abilities:
+        return None
+
+    return {
+        "pokemon": pokemon_slug,
+        "usage_percent": usage_percent,
+        "rank": rank,
+        "raw_count": None,
+        "moves": moves,
+        "items": items,
+        "abilities": abilities,
+        "teammates": teammates,
+        "spreads": [],  # spreads are lower priority; leave empty for v1
+    }
+```
+
+- [ ] **Step 5: Run parser tests and iterate**
+
+```bash
+uv run python -m pytest tests/test_fetcher_pikalytics_champions.py -v
+```
+
+Expected: `test_parse_handles_404` passes immediately. The three fixture-dependent tests may fail — if so, inspect the real HTML structure:
+
+```bash
+uv run python -c "
+from pathlib import Path
+from bs4 import BeautifulSoup
+html = Path('tests/fixtures/pikalytics_incineroar.html').read_text(encoding='utf-8')
+soup = BeautifulSoup(html, 'html.parser')
+for h in soup.find_all(['h2','h3','h4']):
+    print(h.name, '|', h.get_text(strip=True)[:80])
+" | head -40
+```
+
+Then refine `_section_rows` or `heading_keywords` until `moves`, `items`, `abilities`, and `teammates` each return non-empty lists for the Incineroar fixture. Re-run tests until all four pass.
+
+- [ ] **Step 6: Commit parser**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/pikalytics_champions.py \
+        tests/test_fetcher_pikalytics_champions.py \
+        tests/fixtures/pikalytics_incineroar.html
+git commit -m "feat(champions): add Pikalytics usage parser"
+```
+
+---
+
+## Task 5: Fetch orchestrator and transactional store
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/fetcher/pikalytics_champions.py`
+- Modify: `tests/test_fetcher_pikalytics_champions.py`
+
+- [ ] **Step 1: Write failing store test**
+
+Append to `tests/test_fetcher_pikalytics_champions.py`:
+
+```python
+import aiosqlite
+
+from smogon_vgc_mcp.database.schema import SCHEMA
+from smogon_vgc_mcp.fetcher.pikalytics_champions import store_champions_usage
+
+
+@pytest.mark.asyncio
+async def test_store_creates_snapshot_and_rows() -> None:
+    payload = [
+        {
+            "pokemon": "incineroar",
+            "usage_percent": 35.8,
+            "rank": 1,
+            "raw_count": None,
+            "moves": [("Fake Out", 95.2), ("Flare Blitz", 78.1)],
+            "items": [("Safety Goggles", 40.0)],
+            "abilities": [("Intimidate", 100.0)],
+            "teammates": [("Farigiraf", 22.0)],
+            "spreads": [],
+        }
+    ]
+    async with aiosqlite.connect(":memory:") as db:
+        await db.executescript(SCHEMA)
+        snapshot_id, count = await store_champions_usage(
+            db, elo_cutoff="0+", pokemon_data=payload
+        )
+        assert snapshot_id > 0
+        assert count == 1
+        async with db.execute(
+            "SELECT COUNT(*) FROM champions_usage_moves"
+        ) as cursor:
+            (moves_count,) = await cursor.fetchone()
+        async with db.execute(
+            "SELECT COUNT(*) FROM champions_usage_abilities"
+        ) as cursor:
+            (ab_count,) = await cursor.fetchone()
+    assert moves_count == 2
+    assert ab_count == 1
+
+
+@pytest.mark.asyncio
+async def test_store_replaces_same_elo_snapshot() -> None:
+    async with aiosqlite.connect(":memory:") as db:
+        await db.executescript(SCHEMA)
+        first = [{"pokemon": "incineroar", "usage_percent": 35.8, "rank": 1,
+                  "raw_count": None, "moves": [("A", 10.0)], "items": [],
+                  "abilities": [], "teammates": [], "spreads": []}]
+        await store_champions_usage(db, elo_cutoff="0+", pokemon_data=first)
+        second = [{"pokemon": "incineroar", "usage_percent": 40.0, "rank": 1,
+                   "raw_count": None, "moves": [("B", 20.0)], "items": [],
+                   "abilities": [], "teammates": [], "spreads": []}]
+        await store_champions_usage(db, elo_cutoff="0+", pokemon_data=second)
+        async with db.execute(
+            "SELECT COUNT(*) FROM champions_usage_snapshots"
+        ) as cursor:
+            (snap_count,) = await cursor.fetchone()
+        async with db.execute(
+            "SELECT move, percent FROM champions_usage_moves"
+        ) as cursor:
+            rows = await cursor.fetchall()
+    assert snap_count == 1
+    assert rows == [("B", 20.0)]
+```
+
+- [ ] **Step 2: Run tests, expect failure**
+
+```bash
+uv run python -m pytest tests/test_fetcher_pikalytics_champions.py::test_store_creates_snapshot_and_rows -v
+```
+
+Expected: `ImportError`.
+
+- [ ] **Step 3: Implement store + orchestrator**
+
+Append to `src/smogon_vgc_mcp/fetcher/pikalytics_champions.py`:
+
+```python
+import asyncio
+from pathlib import Path
+
+import aiosqlite
+
+from smogon_vgc_mcp.database.schema import get_connection, get_db_path, init_database
+from smogon_vgc_mcp.resilience import get_all_circuit_states
+from smogon_vgc_mcp.utils import fetch_text_resilient
+
+PIKALYTICS_URL_TEMPLATE = "https://www.pikalytics.com/pokedex/championspreview/{slug}"
+
+# Known Champions Pokemon with Pikalytics data (as of 2026-04-08)
+PIKALYTICS_POKEMON_SLUGS = [
+    "incineroar", "sneasler", "sinistcha", "archaludon", "whimsicott",
+    "pelipper", "ursaluna", "garchomp", "farigiraf", "dragonite",
+    "charizard", "basculegion", "tyranitar", "kingambit",
+]
+
+ELO_CUTOFFS = ["0+", "1500+", "1630+", "1760+"]
+
+
+async def store_champions_usage(
+    db: aiosqlite.Connection,
+    elo_cutoff: str,
+    pokemon_data: list[dict],
+    *,
+    _commit: bool = True,
+) -> tuple[int, int]:
+    """Upsert a Pikalytics snapshot for one ELO cutoff.
+
+    If a snapshot already exists for (source, elo_cutoff), its rows are
+    cleared (via ON DELETE CASCADE) by deleting the old snapshot row first,
+    then a fresh snapshot + children are inserted.
+
+    Returns (snapshot_id, pokemon_count).
+    """
+    # Remove any existing snapshot for this cutoff to get clean cascade
+    await db.execute(
+        "DELETE FROM champions_usage_snapshots WHERE source = 'pikalytics' AND elo_cutoff = ?",
+        (elo_cutoff,),
+    )
+
+    cursor = await db.execute(
+        "INSERT INTO champions_usage_snapshots (elo_cutoff, source) VALUES (?, 'pikalytics')",
+        (elo_cutoff,),
+    )
+    snapshot_id = cursor.lastrowid
+    assert snapshot_id is not None
+
+    count = 0
+    for entry in pokemon_data:
+        poke_cursor = await db.execute(
+            """INSERT INTO champions_pokemon_usage
+               (snapshot_id, pokemon, usage_percent, rank, raw_count)
+               VALUES (?, ?, ?, ?, ?)""",
+            (
+                snapshot_id,
+                entry["pokemon"],
+                entry.get("usage_percent"),
+                entry.get("rank"),
+                entry.get("raw_count"),
+            ),
+        )
+        pu_id = poke_cursor.lastrowid
+        assert pu_id is not None
+
+        for move, pct in entry.get("moves", []):
+            await db.execute(
+                "INSERT INTO champions_usage_moves (pokemon_usage_id, move, percent) VALUES (?, ?, ?)",
+                (pu_id, move, pct),
+            )
+        for item, pct in entry.get("items", []):
+            await db.execute(
+                "INSERT INTO champions_usage_items (pokemon_usage_id, item, percent) VALUES (?, ?, ?)",
+                (pu_id, item, pct),
+            )
+        for ability, pct in entry.get("abilities", []):
+            await db.execute(
+                "INSERT INTO champions_usage_abilities (pokemon_usage_id, ability, percent) VALUES (?, ?, ?)",
+                (pu_id, ability, pct),
+            )
+        for teammate, pct in entry.get("teammates", []):
+            await db.execute(
+                "INSERT INTO champions_usage_teammates (pokemon_usage_id, teammate, percent) VALUES (?, ?, ?)",
+                (pu_id, teammate, pct),
+            )
+        count += 1
+
+    if _commit:
+        await db.commit()
+    return snapshot_id, count
+
+
+async def fetch_pikalytics_pokemon(slug: str) -> dict | None:
+    """Fetch a single Pokemon page from Pikalytics and parse it."""
+    url = PIKALYTICS_URL_TEMPLATE.format(slug=slug)
+    result = await fetch_text_resilient(url, service="pikalytics")
+    if not result.success or not result.data:
+        return None
+    return parse_pikalytics_page(result.data, pokemon_slug=slug)
+
+
+async def fetch_and_store_pikalytics_champions(
+    db_path: Path | None = None,
+    *,
+    elo_cutoff: str = "0+",
+    dry_run: bool = False,
+    slugs: list[str] | None = None,
+    request_delay: float = 1.0,
+) -> dict:
+    """Fetch all Pikalytics Champions pages and store atomically.
+
+    One snapshot per ELO cutoff. Callers loop over cutoffs if they want
+    the full matrix.
+    """
+    if db_path is None:
+        db_path = get_db_path()
+    await init_database(db_path)
+
+    target_slugs = slugs if slugs is not None else PIKALYTICS_POKEMON_SLUGS
+    errors: list[dict] = []
+    results: list[dict] = []
+
+    for slug in target_slugs:
+        data = await fetch_pikalytics_pokemon(slug)
+        if data is None:
+            errors.append({"slug": slug, "message": "Failed to fetch or parse page"})
+        else:
+            results.append(data)
+        if request_delay > 0:
+            await asyncio.sleep(request_delay)
+
+    if dry_run:
+        return {
+            "fetched": len(results),
+            "stored": 0,
+            "errors": errors,
+            "circuit_states": get_all_circuit_states(),
+            "dry_run": True,
+            "results": results,
+        }
+
+    snapshot_id = 0
+    stored = 0
+    async with get_connection(db_path) as db:
+        try:
+            snapshot_id, stored = await store_champions_usage(
+                db, elo_cutoff=elo_cutoff, pokemon_data=results, _commit=False
+            )
+            await db.commit()
+        except Exception as exc:
+            await db.rollback()
+            errors.append({"slug": "store", "message": str(exc)})
+
+    return {
+        "fetched": len(results),
+        "stored": stored,
+        "snapshot_id": snapshot_id,
+        "elo_cutoff": elo_cutoff,
+        "errors": errors,
+        "circuit_states": get_all_circuit_states(),
+        "dry_run": False,
+    }
+```
+
+- [ ] **Step 4: Register `pikalytics` circuit breaker**
+
+The `service="pikalytics"` arg to `fetch_text_resilient` must be registered. Check where services are registered:
+
+```bash
+uv run python -c "
+from smogon_vgc_mcp import resilience
+print(resilience.get_all_circuit_states())
+"
+```
+
+If `pikalytics` is missing, find the service registry (grep for `serebii` in `src/smogon_vgc_mcp/resilience.py` and `src/smogon_vgc_mcp/utils.py`) and add a `pikalytics` entry alongside `serebii` with the same defaults. If services are implicitly created on first use, no change needed — confirm by reading the relevant code.
+
+- [ ] **Step 5: Run store tests**
+
+```bash
+uv run python -m pytest tests/test_fetcher_pikalytics_champions.py -v
+```
+
+Expected: all 6 tests pass. Fix any issues.
+
+- [ ] **Step 6: Type-check, lint, commit**
+
+```bash
+uv run ty check src/smogon_vgc_mcp/fetcher/pikalytics_champions.py
+uv run ruff check --fix src/smogon_vgc_mcp/fetcher/pikalytics_champions.py \
+                       tests/test_fetcher_pikalytics_champions.py
+uv run ruff format src/smogon_vgc_mcp/fetcher/pikalytics_champions.py \
+                   tests/test_fetcher_pikalytics_champions.py
+uv run python -m pytest tests/test_fetcher_pikalytics_champions.py -v
+```
+
+All green:
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/pikalytics_champions.py \
+        tests/test_fetcher_pikalytics_champions.py
+git commit -m "feat(champions): add Pikalytics fetch + store orchestrator"
+```
+
+---
+
+## Task 6: Query helpers and MCP tool
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/database/queries.py`
+- Create: `src/smogon_vgc_mcp/tools/champions_usage.py`
+- Modify: `src/smogon_vgc_mcp/tools/__init__.py`
+- Modify: `src/smogon_vgc_mcp/server.py`
+- Create: `tests/test_tools_champions_usage.py`
+
+- [ ] **Step 1: Write failing query test**
+
+Create `tests/test_tools_champions_usage.py`:
+
+```python
+"""Tests for champions usage MCP tool and query helpers."""
+
+import aiosqlite
+import pytest
+
+from smogon_vgc_mcp.database.queries import get_champions_usage
+from smogon_vgc_mcp.database.schema import SCHEMA
+from smogon_vgc_mcp.fetcher.pikalytics_champions import store_champions_usage
+
+
+async def _seed(db: aiosqlite.Connection) -> None:
+    await db.executescript(SCHEMA)
+    await store_champions_usage(
+        db,
+        elo_cutoff="0+",
+        pokemon_data=[
+            {
+                "pokemon": "incineroar",
+                "usage_percent": 35.8,
+                "rank": 1,
+                "raw_count": None,
+                "moves": [("Fake Out", 95.2)],
+                "items": [("Safety Goggles", 40.0)],
+                "abilities": [("Intimidate", 100.0)],
+                "teammates": [("Farigiraf", 22.0)],
+                "spreads": [],
+            }
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_champions_usage_returns_full_payload(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("SMOGON_VGC_DB_PATH", str(db_path))
+    async with aiosqlite.connect(db_path) as db:
+        await _seed(db)
+    result = await get_champions_usage("incineroar", elo_cutoff="0+")
+    assert result is not None
+    assert result["pokemon"] == "incineroar"
+    assert result["usage_percent"] == 35.8
+    assert ("Fake Out", 95.2) in result["moves"]
+    assert result["abilities"] == [("Intimidate", 100.0)]
+
+
+@pytest.mark.asyncio
+async def test_get_champions_usage_returns_none_for_missing(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("SMOGON_VGC_DB_PATH", str(db_path))
+    async with aiosqlite.connect(db_path) as db:
+        await db.executescript(SCHEMA)
+    result = await get_champions_usage("missingno", elo_cutoff="0+")
+    assert result is None
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+```bash
+uv run python -m pytest tests/test_tools_champions_usage.py -v
+```
+
+Expected: `ImportError: cannot import name 'get_champions_usage'`.
+
+- [ ] **Step 3: Implement query helper**
+
+In `src/smogon_vgc_mcp/database/queries.py`, add (near the other Champions queries):
+
+```python
+async def get_champions_usage(
+    pokemon: str, elo_cutoff: str = "0+"
+) -> dict | None:
+    """Return the latest Pikalytics usage payload for a Pokemon + ELO cutoff.
+
+    Returns None if no snapshot exists or the Pokemon is absent.
+    """
+    async with get_connection() as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            """SELECT pu.id, pu.pokemon, pu.usage_percent, pu.rank, pu.raw_count
+               FROM champions_pokemon_usage pu
+               JOIN champions_usage_snapshots s ON s.id = pu.snapshot_id
+               WHERE s.source = 'pikalytics'
+                 AND s.elo_cutoff = ?
+                 AND pu.pokemon = ?
+               ORDER BY s.fetched_at DESC
+               LIMIT 1""",
+            (elo_cutoff, pokemon),
+        ) as cursor:
+            header = await cursor.fetchone()
+        if header is None:
+            return None
+        pu_id = header["id"]
+
+        async def _rows(table: str, col: str) -> list[tuple[str, float]]:
+            async with db.execute(
+                f"SELECT {col}, percent FROM {table} WHERE pokemon_usage_id = ? ORDER BY percent DESC",
+                (pu_id,),
+            ) as c:
+                return [(r[0], r[1]) async for r in c]
+
+        moves = await _rows("champions_usage_moves", "move")
+        items = await _rows("champions_usage_items", "item")
+        abilities = await _rows("champions_usage_abilities", "ability")
+        teammates = await _rows("champions_usage_teammates", "teammate")
+
+    return {
+        "pokemon": header["pokemon"],
+        "elo_cutoff": elo_cutoff,
+        "usage_percent": header["usage_percent"],
+        "rank": header["rank"],
+        "raw_count": header["raw_count"],
+        "moves": moves,
+        "items": items,
+        "abilities": abilities,
+        "teammates": teammates,
+    }
+```
+
+- [ ] **Step 4: Run query tests**
+
+```bash
+uv run python -m pytest tests/test_tools_champions_usage.py -v
+```
+
+Expected: both query tests pass. Fix issues before moving on.
+
+- [ ] **Step 5: Write failing MCP tool test**
+
+Append to `tests/test_tools_champions_usage.py`:
+
+```python
+from mcp.server.fastmcp import FastMCP
+
+from smogon_vgc_mcp.tools.champions_usage import register_champions_usage_tools
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_returns_usage(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("SMOGON_VGC_DB_PATH", str(db_path))
+    async with aiosqlite.connect(db_path) as db:
+        await _seed(db)
+
+    mcp = FastMCP("test")
+    register_champions_usage_tools(mcp)
+
+    # Invoke the registered tool directly
+    tools = await mcp.list_tools()
+    tool_names = [t.name for t in tools]
+    assert "get_champions_usage_stats" in tool_names
+
+    result = await mcp.call_tool(
+        "get_champions_usage_stats",
+        {"pokemon": "Incineroar", "elo_cutoff": "0+"},
+    )
+    # FastMCP call_tool returns a list of content items; the JSON payload is in the first
+    assert result  # non-empty
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_returns_error_for_missing(monkeypatch, tmp_path) -> None:
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("SMOGON_VGC_DB_PATH", str(db_path))
+    async with aiosqlite.connect(db_path) as db:
+        await db.executescript(SCHEMA)
+
+    mcp = FastMCP("test")
+    register_champions_usage_tools(mcp)
+
+    result = await mcp.call_tool(
+        "get_champions_usage_stats",
+        {"pokemon": "Missingno", "elo_cutoff": "0+"},
+    )
+    assert result  # error response is still non-empty
+```
+
+- [ ] **Step 6: Run test, expect failure**
+
+```bash
+uv run python -m pytest tests/test_tools_champions_usage.py -v
+```
+
+Expected: `ModuleNotFoundError: smogon_vgc_mcp.tools.champions_usage`.
+
+- [ ] **Step 7: Implement MCP tool**
+
+Create `src/smogon_vgc_mcp/tools/champions_usage.py`:
+
+```python
+"""Champions usage MCP tool backed by Pikalytics data."""
+
+from mcp.server.fastmcp import FastMCP
+
+from smogon_vgc_mcp.database.queries import get_champions_usage
+from smogon_vgc_mcp.utils import make_error_response
+
+
+def _normalize_pokemon_id(pokemon: str) -> str:
+    return pokemon.lower().replace(" ", "").replace("-", "")
+
+
+def register_champions_usage_tools(mcp: FastMCP) -> None:
+    """Register Champions usage tools with the MCP server."""
+
+    @mcp.tool()
+    async def get_champions_usage_stats(
+        pokemon: str,
+        elo_cutoff: str = "0+",
+    ) -> dict:
+        """Get Pikalytics usage statistics for a Pokemon in Champions format.
+
+        Returns usage %, rank, top moves, items, abilities, and teammates
+        for the given ELO cutoff ("0+", "1500+", "1630+", "1760+").
+
+        Examples:
+        - "Incineroar usage stats in Champions"
+        - "What moves does Garchomp run in Champions at 1760+?"
+
+        Args:
+            pokemon: Pokemon name (e.g., "Incineroar", "Garchomp").
+            elo_cutoff: ELO cutoff: "0+", "1500+", "1630+", or "1760+".
+        """
+        valid_cutoffs = {"0+", "1500+", "1630+", "1760+"}
+        if elo_cutoff not in valid_cutoffs:
+            return make_error_response(
+                f"Invalid elo_cutoff '{elo_cutoff}'",
+                hint=f"Must be one of: {sorted(valid_cutoffs)}",
+            )
+
+        pokemon_id = _normalize_pokemon_id(pokemon)
+        result = await get_champions_usage(pokemon_id, elo_cutoff=elo_cutoff)
+        if result is None:
+            return make_error_response(
+                f"No Champions usage data for '{pokemon}' at {elo_cutoff}",
+                hint="Run the Pikalytics fetcher first, or try a different Pokemon/ELO",
+            )
+        return result
+```
+
+- [ ] **Step 8: Wire into tools/__init__.py and server.py**
+
+In `src/smogon_vgc_mcp/tools/__init__.py`, add alongside the other registration imports:
+
+```python
+from smogon_vgc_mcp.tools.champions_usage import register_champions_usage_tools
+```
+
+and append `"register_champions_usage_tools"` to `__all__`.
+
+In `src/smogon_vgc_mcp/server.py`, find the line `register_champions_calculator_tools(logged_mcp)` and add directly after it:
+
+```python
+register_champions_usage_tools(logged_mcp)
+```
+
+(import `register_champions_usage_tools` at the top of the file alongside the other tool imports).
+
+- [ ] **Step 9: Run the full new test suite**
+
+```bash
+uv run python -m pytest tests/test_tools_champions_usage.py \
+                        tests/test_fetcher_pikalytics_champions.py \
+                        tests/test_fetcher_champions_moves.py \
+                        tests/test_database_champions_usage_schema.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 10: Type-check, lint, commit**
+
+```bash
+uv run ty check src/smogon_vgc_mcp/tools/champions_usage.py \
+                src/smogon_vgc_mcp/server.py \
+                src/smogon_vgc_mcp/database/queries.py
+uv run ruff check --fix src/smogon_vgc_mcp/tools/ \
+                       src/smogon_vgc_mcp/database/queries.py \
+                       tests/test_tools_champions_usage.py
+uv run ruff format src/smogon_vgc_mcp/tools/ \
+                   src/smogon_vgc_mcp/database/queries.py \
+                   tests/test_tools_champions_usage.py
+```
+
+All green:
+
+```bash
+git add src/smogon_vgc_mcp/tools/champions_usage.py \
+        src/smogon_vgc_mcp/tools/__init__.py \
+        src/smogon_vgc_mcp/server.py \
+        src/smogon_vgc_mcp/database/queries.py \
+        tests/test_tools_champions_usage.py
+git commit -m "feat(champions): expose Pikalytics usage via MCP tool"
+```
+
+---
+
+## Task 7: End-to-end smoke (live network, optional)
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Run Serebii moves fetch live**
+
+```bash
+uv run python -c "
+import asyncio
+from smogon_vgc_mcp.fetcher.champions_moves import fetch_and_store_champions_moves
+print(asyncio.run(fetch_and_store_champions_moves(dry_run=True)))
+"
+```
+
+Expected: `fetched` > 0, `errors` empty (or only minor parse warnings). If 0 fetched, debug the parser against the live page.
+
+- [ ] **Step 2: Run Pikalytics fetch live (dry run)**
+
+```bash
+uv run python -c "
+import asyncio
+from smogon_vgc_mcp.fetcher.pikalytics_champions import fetch_and_store_pikalytics_champions
+print(asyncio.run(fetch_and_store_pikalytics_champions(dry_run=True, slugs=['incineroar'])))
+"
+```
+
+Expected: `fetched: 1`, `errors: []`, one dict in `results` with non-empty moves/items/abilities.
+
+- [ ] **Step 3: Run the full test suite to catch regressions**
+
+```bash
+uv run python -m pytest -x --ignore=tests/integration 2>&1 | tail -40
+```
+
+Expected: new tests pass, no regressions introduced in the existing 53 pre-existing failures (which are unrelated to this work). If new failures appear in Champions or fetcher tests, fix before closing out.
+
+- [ ] **Step 4: Final commit (if any cleanup needed)**
+
+If Steps 1–3 surfaced fixes, commit them:
+
+```bash
+git add -u
+git commit -m "fix(champions): address smoke test findings"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Phase 1 delivers Serebii move changes (parser + store + queries). Phase 2 delivers Pikalytics usage data (schema + model + parser + store + query + MCP tool). Both follow the two-phase fetch/store pattern from `champions_dex.py`.
+- **Open assumptions:** Serebii updatedattacks page layout and Pikalytics heading structure are validated against fixtures in Tasks 1 and 4; parsers may need minor tweaks after inspecting real HTML. The `pikalytics` circuit breaker registration (Task 5 Step 4) depends on how `fetch_text_resilient` manages services — confirm during implementation.
+- **Out of scope (v1):** Pikalytics spread parsing is stubbed (empty list). Multi-ELO scraping in a single run is supported but the caller must loop over `ELO_CUTOFFS`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "aiosqlite>=0.20.0",
     "tenacity>=8.2.0",
     "anthropic>=0.40.0",
+    "beautifulsoup4>=4.12",
 ]
 
 [project.optional-dependencies]

--- a/src/smogon_vgc_mcp/database/queries.py
+++ b/src/smogon_vgc_mcp/database/queries.py
@@ -7,8 +7,8 @@ import aiosqlite
 
 from smogon_vgc_mcp.database.models import (
     AbilityUsage,
-    CheckCounter,
     ChampionsDexPokemon,
+    CheckCounter,
     DexAbility,
     DexItem,
     DexMove,

--- a/tests/fixtures/serebii_charizard.html
+++ b/tests/fixtures/serebii_charizard.html
@@ -1,0 +1,2386 @@
+
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Charizard - #006 - Serebii.net Pok&eacute;dex</title>
+
+<script data-cfasync="false">
+  window.ramp = window.ramp || {};
+  window.ramp.que = window.ramp.que || [];
+</script>
+
+<meta http-equiv="imagetoolbar" CONTENT="no">
+	<link rel="stylesheet" type="text/css" href="/style/layout.css" />
+<meta name="viewport" content="width=device-width,initial-scale=1" id="viewport-meta">
+
+<!-- GDPR Compliancy -->
+<style>
+body {
+	--cmpBgColor: #507C36;
+	--cmpTextColor: #000000;
+	--cmpLinkColor: #ffffff;
+	--cmpPurposesColor: #000000;
+	--cmpBrandColor: #000000;
+	--cmpLogo: url('https://www.serebii.net/extralogo.png');
+}
+</style>
+<!-- GDPR Compliancy -->
+
+<link rel="search" href="/serebii-opensearch.xml" type="application/opensearchdescription+xml" title="Serebii Open Search" />
+<link rel="shortcut icon" href="/favicon.ico" />
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-128947957-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'UA-128947957-1');
+</script>
+<!-- Place the below code anywhere you like in the <head> (higher is better) -->
+
+
+
+<meta name="keywords" content="Pokemon, Pok&eacute;dex, Charizard (Pok&eacute;mon),Charizard, Charizard, Champions" />
+<link rel="stylesheet" type="text/css" HREF="/style/dexy-new.css">
+<link rel="canonical" href="https://www.serebii.net/pokedex-champions/charizard" />
+<meta property="og:image" content="https://www.serebii.net/pokemon/art/006.png">
+<meta property="og:title" content="Charizard #006 - Serebii.net Pok&eacute;dex">
+<meta property="og:description" content="Charizard Pok&eacute;mon Serebii.net Pok&eacute;dex providing all details on moves, stats, abilities, evolution data and locations for Pok&eacute;mon Champions">
+<meta name="description" content="Charizard Pok&eacute;mon Serebii.net Pok&eacute;dex providing all details on moves, stats, abilities, evolution data and locations for Pok&eacute;mon Scarlet & Violet and Pok&eacute;mon Legends: Z-A">
+<meta name="twitter:card" content="summary_large_image">
+<style type="text/css">h1 {font-size:14pt;font-weight:bold;margin-bottom:0px;} h2 { font-size:1em;font-weight:bold;margin-top:0px;margin-bottom:0px; } h3 {font-size:1em;font-weight: bold;margin-top:0px;margin-bottom:0px;}  .radar-graph{        width:500px;    height:500px;    position:relative;   }    .radar-graph .polygon{    background-color:#507C36;    width:100%;    height:100%;    opacity:70%   }   .radar-graph .label{    position:absolute;    color:white;    transform:translate(-50%,-50%);   }</style>
+
+
+
+
+</head>
+<body>
+<script type="text/javascript">
+	var viewport_meta = document.getElementById('viewport-meta');
+	var viewport_timer;
+
+	// these body*Class are reused in the lbar mobile menu
+	function bodyAddClass(className){
+		if(document.body) document.body.classList.add(className);
+	}
+	function bodyRemoveClass(className){
+		if(document.body) document.body.className = document.body.className.replace(className,"");
+	}
+
+	function viewport_set() {
+		// Define our viewport meta values
+		var viewports = {
+			default: viewport_meta.getAttribute('content'),
+			mobileL: 'width=device-width,initial-scale=0.75',
+			mobileM: 'width=device-width,initial-scale=0.5',
+			mobileS: 'width=device-width,initial-scale=0.4'
+		};
+
+		// Change the viewport value based on screen.width
+		if(screen.width < 370){
+			viewport_meta.setAttribute('content', viewports.mobileS);
+			bodyAddClass("nav_mobileS");
+			bodyRemoveClass("nav_mobileM");
+			bodyRemoveClass("nav_mobileL");
+		} else if(screen.width < 505){
+			viewport_meta.setAttribute('content', viewports.mobileM);
+			bodyRemoveClass("nav_mobileS");
+			bodyAddClass("nav_mobileM");
+			bodyRemoveClass("nav_mobileL");
+		} else if (screen.width < 760){
+			viewport_meta.setAttribute('content', viewports.mobileL);
+			bodyRemoveClass("nav_mobileS");
+			bodyRemoveClass("nav_mobileM");
+			bodyAddClass("nav_mobileL");
+		} else{
+			viewport_meta.setAttribute('content', viewports.default);
+			bodyRemoveClass("nav_mobileS");
+			bodyRemoveClass("nav_mobileM");
+			bodyRemoveClass("nav_mobileL");
+		}
+	}
+
+	// Set the correct viewport value on page load
+	viewport_set();
+
+	/* attach listener to (delay) set the correct viewport after device orientation change or resize. also onload so the nav_mobile* class gets added to body AFTER <body> has loaded */
+	if(window.addEventListener){
+		window.addEventListener('load', viewport_set);
+		window.addEventListener('resize', function(){
+			clearTimeout(viewport_timer);
+			viewport_timer = setTimeout(viewport_set, 100);
+		})
+	} else{
+		window.attachEvent('onload', viewport_set)
+		window.attachEvent('onresize', function(){
+			clearTimeout(viewport_timer);
+			viewport_timer = setTimeout(viewport_set, 100);
+		})
+	}
+
+</script>
+
+
+<header id="header">
+	<div class="banner">
+		<a href="/"><img src="/Banner.jpg" alt="Serebii.net Header" style="height:139px"></a>
+	</div>
+
+	<nav class="quicklinks">
+		<ul>
+			<li><b>Quick Links</b></li>
+			<li><a href="/index2.shtml">Home</a></li>
+			<li><a href="https://forums.serebii.net/" target="blank">Forums</a></li>
+			<li><a href="mailto:webmaster@serebii.net">Contact</a></li>
+			<li><a href="/discord.shtml">Discord</a></li>
+			<li><a href="/pokemon">Pokédex Hub</a></li>
+			<li><a href="/pokedex-sv">Scarlet & Violet Pokédex</a></li>
+			<li><a href="/pokedex-champions">Champions Pokédex</a></li>
+			<li><a href="/pokearth">Pokéarth</a></li>
+
+			<li class="search">
+				<form id="searchbox_018410473690156091934:6gahkiyodbi" action="/search.shtml" style="margin:0px;">
+					<input type="hidden" name="cx" value="018410473690156091934:6gahkiyodbi" />
+					<input type="hidden" name="cof" value="FORID:11" />
+					<input name="q" type="text" size="20" />
+					<input type="submit" name="sa" value="Search" />
+				</form>
+				<script type="text/javascript" src="//www.google.com/coop/cse/brand?form=searchbox_018410473690156091934%3A6gahkiyodbi"></script>
+			</li>
+		</ul>
+	</nav>
+</header>
+
+
+<div id="wrapper">
+
+<ul id="tbar_sticky">
+	<li>
+		<a href="#lbar" class="navheader" id="tbar_lbar_open"><img src="/hidden/2019-04/burger.svg"></a>
+	</li>
+	<li>
+		<form id="searchbox_018410473690156091934:6gahkiyodbi" action="/search.shtml" style="margin:0px;">
+			<input type="hidden" name="cx" value="018410473690156091934:6gahkiyodbi" />
+			<input type="hidden" name="cof" value="FORID:11" />
+			<input name="q" type="search" placeholder="Search Serebii.net..." />
+		</form>
+	</li>
+	<li>
+		<a href="#rbar" class="navheader" id="tbar_rbar_open" style="padding-right:20px"><img src="/hidden/2019-04/burger.svg"></a>
+	</li>
+</ul>
+<div id="tbar_backdrop"></div>
+
+<nav id="lbar">
+	<ul id="lbar_ul">
+		<li>
+			<a href="/" class="navheader">Databases</a>
+			<ul>
+				<li><a href="/index2.shtml">News</a>
+				<li><a href="/archive.shtml">Archived news</a></li>
+				<li><a href="/pokemon/"><b>Pokédex</b></a></li>
+				<li><a href="/pokedex/">-Red/Blue Pokédex</a></li>
+				<li><a href="/pokedex-gs/">-Gold/Silver Pokédex</a></li>
+				<li><a href="/pokedex-rs/">-Ruby/Sapphire Pokédex</a></li>
+				<li><a href="/pokedex-dp/">-Diamond/Pearl Pokédex</a></li>
+				<li><a href="/pokedex-bw/">-Black/White Pokédex</a></li>
+				<li><a href="/pokedex-xy/">-X & Y Pokédex</a></li>
+				<li><a href="/pokedex-sm/">-Sun & Moon Pokédex</a></li>
+				<li><a href="/pokedex-sm/">-Let's Go Pokédex</a></li>
+				<li><a href="/pokedex-swsh/">-Sword & Shield Pokédex</a></li>
+				<li><a href="/pokedex-swsh/">-BDSP Pokédex</a></li>
+				<li><a href="/pokedex-swsh/">-Legends: Arceus Pokédex</a></li>
+				<li><a href="/pokemongo/pokemon/">-GO Pokédex</a></li>
+				<li><a href="/pokedex-sv/">-Scarlet & Violet Pokédex</a></li>
+				<li><a href="/pokedex-sv/">-Legends: Z-A Pokédex</a></li>
+				<li><a href="/pokedex-champions/">-Champions Pokédex</a></li>
+
+				<li><strong>Attackdex</strong></li>
+				<li><a href="/attackdex-rby/">-Gen 1 Attackdex</a></li>
+				<li><a href="/attackdex-gs/">-Gen 2 Attackdex</a></li>
+				<li><a href="/attackdex/">-Gen 3 Attackdex</a></li>
+				<li><a href="/attackdex-dp/">-Gen 4 Attackdex</a></li>
+				<li><a href="/attackdex-bw/">-Gen 5 Attackdex</a></li>
+				<li><a href="/attackdex-xy/">-Gen 6 Attackdex</a></li>
+				<li><a href="/attackdex-sm/">-Gen 7 Attackdex</a></li>
+				<li><a href="/attackdex-swsh/">-Gen 8 Attackdex</a></li>
+				<li><a href="/attackdex-sv/">-Gen 9 Attackdex</a></li>
+				<li><a href="/attackdex-champions/">-Champions Attackdex</a></li>
+				<li><a href="/itemdex/">ItemDex</a></li>
+				<li><a href="/pokearth/">Pokéarth</a></li>
+				<li><a href="/abilitydex/">Abilitydex</a></li>
+				<li><a href="/spindex/">Spin-Off Pokédex</a></li>
+				<li><a href="/spindex-dp/">Spin-Off Pokédex DP</a></li>
+				<li><a href="/spindex-bw/">Spin-Off Pokédex BW</a></li>
+				<li><a href="/card/dex/">Cardex</a></li>
+				<li><a href="/movies/dex/">Cinematic Pokédex</a></li>
+				<li><a href="/games/mechanics.shtml">Game Mechanics</a></li>
+				<li><a href="/games/iv-calcsv.shtml">-Scarlet/Violet IV Calc.</a></li>
+				<li><a href="/potw-sv">Pokémon of the Week</a></li>
+				<li><a href="/potw-sv/">-9th Gen</a></li>
+				<li><a href="/potw-swsh/">-8th Gen</a></li>
+				<li><a href="/potw-sm/">-7th Gen</a></li>
+				<li><a href="/pokemon/timeline.shtml">Pokémon Timeline</a></li>
+				<li><a href="/pokemoncenter/">Pokémon Centers</a></li>
+				<li><a href="/playpokemon">Pokémon Championship Series</a></li>
+				<li><a href="/pokemonxp/">PokémonXP</a></li>
+
+				<li><a href="/music/projectvoltage">Hatsune Miku Project Voltage</a></li>
+				<li><a href="/museums/">Pokémon in Museums & Exhibitions</a></li>
+				<li><a href="/pokemon/vangoghmuseum/">-Pokémon x Van Gogh</a></li>
+				<li><a href="/pokemonday/">Pokémon Day</a></li>
+				<li><a href="/presentations">Pokémon Presentations</a></li>
+				<li><a href="/lego/">LEGO Pokémon</a></li>
+				<li><a href="/pokemonshirts/">Pokémon Shirts</a></li>
+				<li><a href="/themeparks/">Theme Parks</a></li>
+				<li><a href="https://forums.serebii.net" target="blank">Forums</a></li>
+				<li><a href="/discord.shtml">Discord Chat</a></li>		
+				<li><a href="/games/currentevents.shtml">Current & Upcoming Events</a></li>
+				<li><a href="/events">Event Database</a></li>
+				<li><a href="/scarletviolet/pokemon.shtml">9th Generation Pokémon</a></li>
+				<li><a href="/scarletviolet/dlc-pokemon.shtml">-New Pokémon in DLC</a></li>
+				<li><a href="/scarletviolet/paldeanforms.shtml">-Paldean Form Pokémon</a></li>
+
+			</ul>
+		</li>
+
+
+		<li>
+			<a href="/anime/" class="navheader">Anime & TV</a>
+			<ul>
+				<li><a href="/anime/epiguide/">Episode Listings & Pictures</a></li>
+				<li><a href="/anime/dex/">AniméDex</a></li>
+				<li><a href="/anime/characters/">Character Bios</a></li>
+				<li><a href="/anime/epiguide/indigo/">The Indigo League</a></li>
+				<li><a href="/anime/epiguide/orange/">The Orange League</a></li>
+				<li><a href="/anime/epiguide/johto/">The Johto Saga</a></li>
+				<li><a href="/anime/epiguide/houen/">The Saga in Hoenn!</a></li>
+				<li><a href="/anime/epiguide/kanto/">Kanto Battle Frontier Saga!</a></li>
+				<li><a href="/anime/epiguide/shinou/">The Sinnoh Saga!</a></li>
+				<li><a href="/anime/epiguide/bestwishes/">Best Wishes - Unova Saga</a></li>
+				<li><a href="/anime/epiguide/xy/">XY - Kalos Saga</a></li>
+				<li><a href="/anime/epiguide/sunmoon/">Sun & Moon - Alola Saga</a></li>
+				<li><a href="/anime/epiguide/pokemon/">Pokémon Journeys - Galar Saga</a></li>
+				<li><a href="/anime/epiguide/pokemonmaster/">Pokémon Aim To Be A Pokémon Master</a></li>
+				<li><a href="/anime/epiguide/pokemon2023/">Pokémon Horizons - Paldea Saga</a></li>
+				<li><a href="/anime/epiguide/chronicles/">Pokémon Chronicles</a></li>	
+				<li><a href="/anime/epiguide/specials/">The Special Episodes</a></li>
+				<li><a href="/anime/banned.shtml">The Banned Episodes</a></li>
+				<li><a href="/anime/shiny/">Shiny Pokémon</a></li>
+<li><b>Other Web Series</b></li>
+				<li><a href="/anime/epiguide/generations/">Pokémon Generations</a></li>
+				<li><a href="/anime/epiguide/twilightwings/">Pokémon Twilight Wings</a></li>
+				<li><a href="/anime/epiguide/evolutions/">Pokémon Evolutions</a></li>
+				<li><a href="/anime/hisuiansnow/">Pokémon: Hisuian Snow</a></li>
+				<li><a href="/anime/paldeanwinds/">Pokémon: Paldean Winds</a></li>
+				<li><a href="/anime/poketoon/">PokéToon</a></li>
+				<li><a href="/anime/other/pathtothepeak/">Path to the Peak</a></li>
+				<li><a href="/anime/other/pokeminutes/">PokéMinutes</a></li>
+				<li><a href="/anime/other/pokevideodex/">PokéVideoDex</a></li>
+				<li><a href="/anime/other/goodmorningwithpokemon/">Good Morning with Pokémon</a></li>
+				<li><a href="/anime/other/">Other Animations</a></li>
+				<li><b>Other Series</b></li>
+				<li><a href="/pokemonconcierge/">Pokémon Concierge</a></li>
+				<li><a href="/pokemontales/">Pokémon Tales: The Misadventures of Sirfetch'd & Pichu</a></li>
+
+				<li><b>Live Action</b></li>
+				<li><a href="/poketsume/">PokéTsume</a></li>
+
+
+			</ul>
+		</li>
+
+		<li>
+			<a href="/games/" class="navheader">Video Games</a>
+			<ul>
+				<li><a href="/pokemon/generation10.shtml"><b>Gen X</b></li>
+				<li><a href="/windswaves/">Winds & Waves</a></li>
+
+				<li><a href="/pokemon/generation9.shtml"><b>Gen IX</b></a></li>
+				<li><a href="/scarletviolet/">Scarlet & Violet</a></li>
+				<li><a href="/legendsz-a/">Legends: Z-A</a></li>
+				<li><a href="/pokemonchampions/">Pokémon Champions</a></li>
+				<li><a href="/pokemonpokopia/">Pokémon Pokopia</a></li>
+				<li><a href="/pokemonfriends/">Pokémon Friends</a></li>
+				<li><a href="/pokemongo/">Pokémon GO</a></li>
+				<li><a href="/cafemix/">Pokémon Café ReMix</a></li>
+				<li><a href="/pokemonmasters/">Pokémon Masters EX</a></li>
+				<li><a href="/pokemonunite/">Pokémon UNITE</a></li>
+				<li><a href="/pokemonsleep/">Pokémon Sleep</a></li>
+				<li><a href="/detectivepikachureturns/">Detective Pikachu Returns</a></li>
+				<li><a href="/tcgpocket/">Pokémon TCG Pocket</a></li>
+
+				<li><a href="/pokemon/generation8.shtml"><b>Gen VIII</b></a></li>
+				<li><a href="/swordshield/">Sword & Shield</a></li>
+				<li><a href="/brilliantdiamondshiningpearl/">Brilliant Diamond & Shining Pearl</a></li>
+				<li><a href="/legendsarceus/">Pokémon Legends: Arceus</a></li>
+				<li><a href="/pokemonhome/">Pokémon HOME</a></li>
+				<li><a href="/pokemongo/">Pokémon GO</a></li>
+				<li><a href="/pokemonmasters/">Pokémon Masters EX</a></li>
+				<li><a href="/dungeonrescueteamdx/">Pokémon Mystery Dungeon Rescue Team DX</a></li>
+				<li><a href="/pokemonsmile/">Pokémon Smile</a></li>
+				<li><a href="/cafemix/">Pokémon Café ReMix</a></li>
+				<li><a href="/newpokemonsnap/">New Pokémon Snap</a></li>
+				<li><a href="/pokemonunite/">Pokémon UNITE</a></li>
+				<li><a href="/tcglive/">Pokémon TCG Live</a></li>
+
+				<li><a href="/pokemon/generation7.shtml"><b>Gen VII</b></a></li>
+				<li><a href="/sunmoon/">Sun & Moon</a></li>
+				<li><a href="/ultrasunultramoon/">Ultra Sun & Ultra Moon</a></li>
+				<li><a href="/letsgopikachueevee/">Let's Go, Pikachu! & Let's Go, Eevee!</a></li>
+				<li><a href="/pokemongo/">Pokémon GO</a></li>
+				<li><a href="/magikarpjump/">Pokémon: Magikarp Jump</a></li>
+				<li><a href="/rumblerush/">Pokémon Rumble Rush</a></li>
+				<li><a href="/pokkendx/">Pokkén Tournament DX</a></li>
+				<li><a href="/detective/">Detective Pikachu</a></li>
+				<li><a href="/quest/">Pokémon Quest</a></li>
+				<li><a href="/smashbrosultimate/">Super Smash Bros. Ultimate</a></li>
+				<li><a href="/pokemon/generation6.shtml"><b>Gen VI</b></a></li>
+				<li><a href="/xy/">X & Y</a></li>
+				<li><a href="/omegarubyalphasapphire/">Omega Ruby & Alpha Sapphire</a></li>
+				<li><a href="/bank/">Pokémon Bank</a></li>
+				<li><a href="/battletrozei/">Pokémon Battle TrozeiPokémon Link: Battle</a></li>
+				<li><a href="/artacademy/">Pokémon Art Academy</a></li>
+				<li><a href="/bandofthieves/">The Band of Thieves & 1000 Pokémon</a></li>
+				<li><a href="/shuffle/">Pokémon Shuffle</a></li>
+				<li><a href="/rumbleworld/">Pokémon Rumble World</a></li>
+				<li><a href="/supermysterydungeon/">Pokémon Super Mystery Dungeon</a></li>
+				<li><a href="/picross/">Pokémon Picross</a></li>
+				<li><a href="/detective/">Detective Pikachu</a></li>
+				<li><a href="/pokken/">Pokkén Tournament</a></li>
+				<li><a href="/duel/">Pokémon Duel</a></li>
+				<li><a href="/smashbros3dswiiu/">Smash Bros for 3DS/Wii U</a></li>
+				<li><a href="/games/badge/">Nintendo Badge Arcade</a></li>
+				<li><a href="/pokemon/generation5.shtml"><b>Gen V</b></a></li>
+				<li><a href="/blackwhite/">Black & White</a></li>
+				<li><a href="/black2white2/">Black 2 & White 2</a></li>
+				<li><a href="/dreamradar/">Pokémon Dream Radar</a></li>
+				<li><a href="/trettalab/">Pokémon Tretta Lab</a></li>
+				<li><a href="/rumbleu/">Pokémon Rumble U</a></li>
+				<li><a href="/dungeoninfinity/">Mystery Dungeon: Gates to Infinity</a></li>
+				<li><a href="/conquest/">Pokémon Conquest</a></li>
+				<li><a href="/pokepark2/">PokéPark 2: Wonders Beyond</a></li>
+				<li><a href="/rumble2/">Pokémon Rumble Blast</a></li>
+				<li><a href="/pokedex3d/">Pokédex 3D</a></li>
+				<li><a href="/pokedex3dpro/">Pokédex 3D Pro</a></li>
+				<li><a href="/typingds/">Learn With Pokémon: Typing Adventure</a></li>
+				<li><a href="/card/howtoplayds/">TCG How to Play DS</a></li>
+				<li><a href="/pokedexios/">Pokédex for iOS</a></li>
+				<li><a href="/pokemon/generation4.shtml"><b>Gen IV</b></a></li>
+				<li><a href="/diamondpearl/">Diamond & Pearl</a></li>
+				<li><a href="/platinum/">Platinum</a></li>
+				<li><a href="/heartgoldsoulsilver/">Heart Gold & Soul Silver</a></li>
+				<li><a href="/ranger3/">Pokémon Ranger: Guardian Signs</a></li>
+				<li><a href="/melee/">Pokémon Rumble</a></li>
+				<li><a href="/dungeon3/">Mystery Dungeon: Blazing, Stormy & Light Adventure Squad</a></li>
+				<li><a href="/pokepark/">PokéPark Wii - Pikachu's  Adventure</a></li>
+				<li><a href="/battle/">Pokémon Battle Revolution</a></li>
+				<li><a href="/dungeonsky/">Mystery Dungeon - Explorers of Sky</a></li>
+				<li><a href="/ranger2/">Pokémon Ranger: Shadows of Almia</a></li>
+				<li><a href="/dungeon2/">Mystery Dungeon - Explorers of Time & Darkness</a></li>
+				<li><a href="/ranch/">My Pokémon Ranch</a></li>
+				<li><a href="/ssbb/">Smash Bros Brawl</a></li>
+				<li><a href="/pokemon/generation3.shtml"><b>Gen III</b></a></li>
+				<li><a href="/rubysapphire/">Ruby & Sapphire</a></li>
+				<li><a href="/fireredleafgreen/">Fire Red & Leaf Green</a></li>
+				<li><a href="/emerald/">Emerald</a></li>
+				<li><a href="/colosseum/">Pokémon Colosseum</a></li>
+				<li><a href="/xd/">Pokémon XD: Gale of Darkness</a></li>
+				<li><a href="/dash/">Pokémon Dash</a></li>
+				<li><a href="/pokemon_channel/">Pokémon Channel</a></li>
+				<li><a href="/pokemon_box/">Pokémon Box: RS</a></li>
+				<li><a href="/pinball_rs/">Pokémon Pinball RS</a></li>
+				<li><a href="/ranger/">Pokémon Ranger</a></li>
+				<li><a href="/mysteriousdungeon/">Mystery Dungeon Red & Blue</a></li>
+				<li><a href="/torouze/">PokémonTrozei</a></li>
+				<li><a href="/pikachu/">Pikachu DS Tech Demo</a></li>
+				<li><a href="/pokeparkfish/">PokéPark Fishing Rally</a></li>
+				<li><a href="/e-reader/">The E-Reader</a></li>
+				<li><a href="/pokemate/">PokéMate</a></li>
+				<li><a href="/pokemon/generation2.shtml"><b>Gen II</b></a></li>
+				<li><a href="/gs/">Gold/Silver</a></li>
+				<li><a href="/crystal/">Crystal</a></li>
+				<li><a href="/stadium2/">Pokémon Stadium 2</a></li>
+				<li><a href="/puzzlechallenge/">Pokémon Puzzle Challenge</a></li>
+				<li><a href="/mini/">Pokémon Mini</a></li>
+				<li><a href="/smash_bros_2/">Super Smash Bros. Melee</a></li>
+				<li><a href="/pokemon/generation1.shtml"><b>Gen I</b></a></li>
+				<li><a href="/rb/">Red, Blue & Green</a></li>
+				<li><a href="/yellow/">Yellow</a></li>
+				<li><a href="/puzzleleague/">Pokémon Puzzle League</a></li>
+				<li><a href="/snap/">Pokémon Snap</a></li>
+				<li><a href="/pinball/">Pokémon Pinball</a></li>
+				<li><a href="/stadiumjp/">Pokémon Stadium (Japanese)</a></li>
+				<li><a href="/stadium/">Pokémon Stadium</a></li>
+				<li><a href="/tradingcardgamegb/">Pokémon Trading Card Game GB</a></li>
+				<li><a href="/smash_bros/">Super Smash Bros.</a></li>
+
+				<li><strong>Miscellaneous</strong></li>
+				<li><a href="/games/mechanics.shtml">Game Mechanics</a></li>
+				<li><a href="/playpokemon">Pokémon Championship Series</a></li>
+				<li><a href="/games/others.shtml">In Other Games</a></li>
+				<li><a href="/games/virtualconsole.shtml">Virtual Console</a></li>
+				<li><a href="/games/consoles.shtml">Special Edition Consoles</a></li>
+				<li><a href="/games/themes.shtml">Pokémon 3DS Themes</a></li>
+				<li><a href="/apps">Smartphone & Tablet Apps</a></li>
+				<li><a href="/virtualpet">Virtual Pets</a></li>
+				<li><a href="/amiibo">amiibo</a></li>
+				<li><a href="/nintendoswitchonline/">Nintendo Switch Online & Icons</a></li>
+				<li><strong>Board Game</strong></li>
+				<li><a href="/pokemongoita">Pokémon Goita</a></li>
+				<li><strong>Arcade</strong></li>
+				<li><a href="/frienda">Pokémon FRIENDA</a></li>
+			</ul>
+		</li>
+
+		<li>
+			<a href="/manga/" class="navheader">Manga</a>
+			<ul>
+				<li><a href="/manga/">General Information</a>
+				<li><a href="/manga/dex">MangaDex</a></li>
+				<li><a href="/manga/characters">Character BIOs</a></li>
+				<li><a href="/manga/characters-new">Detailed BIOs</a></li>
+				<li><a href="/manga/chapter.shtml">Chapter Guides</a></li>
+				<li><a href="/manga/volume.shtml">Volume Guides</a></li>
+				<li><a href="/manga/rby/">RBG Series</a></li>
+				<li><a href="/manga/yellow/">Yellow Series</a></li>
+				<li><a href="/manga/gsc/">GSC Series</a></li>
+				<li><a href="/manga/rs/">RS Series</a></li>
+				<li><a href="/manga/frlg/">FRLG Series</a></li>
+				<li><a href="/manga/bf/">Emerald Series</a></li>
+				<li><a href="/manga/dp/">DP Series</a></li>
+				<li><a href="/manga/pt/">Platinum Series</a></li>
+				<li><a href="/manga/hgss/">HGSS Series</a></li>
+				<li><a href="/manga/bw/">BW Series</a></li>
+				<li><a href="/manga/b2w2/">B2W2 Series</a></li>
+				<li><a href="/manga/xy/">XY Series</a></li>
+				<li><a href="/manga/oras/">ORAS Series</a></li>
+				<li><a href="/manga/sunmoon/">SM Series</a></li>
+			</ul>
+		</li>
+
+		<li>
+			<a href="/movies/" class="navheader">Movies</a>
+			<ul>
+				<li><strong>Anime</strong></li>
+				<li><a href="/movies/mewtwo/origin/">The Origin of Mewtwo</a></li>
+				<li><a href="/movies/mewtwo/">Mewtwo Strikes Back</a></li>
+				<li><a href="/movies/lugia/">The Power of One</a></li>
+				<li><a href="/movies/entei/">Spell Of The Unown</a></li>
+				<li><a href="/anime/epiguide/specials/002.shtml">Mewtwo Returns</a></li>
+				<li><a href="/movies/serebii/">Celebi: Voice of the Forest</a></li>
+				<li><a href="/movies/latias_latios/">Pokémon Heroes</a></li>
+				<li><a href="/movies/jirachi/">Jirachi - Wish Maker</a></li>
+				<li><a href="/movies/deoxys/">Destiny Deoxys!</a></li>
+				<li><a href="/movies/mew/">Lucario and the Mystery of Mew!</a></li>
+				<li><a href="/movies/kyogre/">Pokémon Ranger & The Temple of the Sea!</a></li>
+				<li><a href="/movies/dp/">The Rise of Darkrai!</a></li>
+				<li><a href="/movies/giratina/">Giratina & The Sky Warrior!</a></li>
+				<li><a href="/movies/arceus/">Arceus and the Jewel of Life</a></li>
+				<li><a href="/movies/celebi/">Zoroark - Master of Illusions</a></li>
+				<li><a href="/movies/victini/">Black: Victini & ReshiramWhite: Victini & Zekrom</a></li>
+				<li><a href="/movies/kyurem/">Kyurem VS The Sword of Justice</a></li>
+				<li><a href="/movies/meloetta/">-Meloetta's Midnight Serenade</a></li>
+				<li><a href="/movies/genesect/">Genesect and the Legend Awakened</a></li>
+				<li><a href="/movies/xy/">Diancie & The Cocoon of Destruction</a></li>
+				<li><a href="/movies/hoopa/">Hoopa & The Clash of Ages</a></li>
+				<li><a href="/movies/volcanion/">Volcanion and the Mechanical Marvel</a></li>
+				<li><a href="/movies/pokemon20/">Pokémon I Choose You!</a></li>
+				<li><a href="/movies/thepowerofus/">Pokémon The Power of Us</a></li>
+				<li><a href="/movies/mewtwoevolution/">Mewtwo Strikes Back Evolution</a></li>
+				<li><a href="/movies/secretsofthejungle/">Secrets of the Jungle</a></li>
+				<li><strong>Live Action</strong></li>
+				<li><a href="/movies/detectivepikachu/">Pokémon Detective Pikachu</a></li>
+			</ul>
+		</li>
+
+		<li>
+			<a href="/movies/" class="navheader">Pikachu Shorts</a>
+			<ul>
+				<li><a href="/movies/pikachu1/">Pikachu's Summer Vacation</a></li>
+				<li><a href="/movies/pikachureturns/">Pikachu's Rescue Adventure</a></li>
+				<li><a href="/movies/pikachu3/">Pikachu And Pichu</a></li>
+				<li><a href="/movies/pikachu4/">Pikachu's PikaBoo</a></li>
+				<li><a href="/movies/pikachu5/">Camp Pikachu!</a></li>
+				<li><a href="/movies/pikachu6/">Gotta Dance!!</a></li>
+				<li><a href="/movies/pikachu7/">Pikachu's Summer Festival!</a></li>
+				<li><a href="/movies/pikachu8/">Pikachu's Ghost Festival!</a></li>
+				<li><a href="/movies/pikachu9/">Pikachu's Island Adventure!</a></li>
+				<li><a href="/movies/pikachu10/">Pikachu's Exploration Club</a></li>
+				<li><a href="/movies/pikachu11/">Pikachu's Great Ice Adventure</a></li>
+				<li><a href="/movies/pikachu12/">Pikachu's Sparkling Search</a></li>
+				<li><a href="/movies/pikachu13/">Pikachu's Really Mysterious Adventure</a></li>
+				<li><a href="/movies/eevee/">Eevee & Friends</a></li>
+				<li><a href="/movies/klefki/">Pikachu, What's This Key?</a></li>
+				<li><a href="/movies/pikachumusic/">Pikachu & The Pokémon Music Squad</a></li>
+			</ul>
+		</li>
+
+		<li>
+			<a href="/card/" class="navheader">Trading Cards</a>
+			<ul>
+				<li><a href="/tcglive/">Pokémon TCG Live</a></li>
+				<li><a href="/card/dex/">Cardex</a></li>
+				<li><a href="/card/dex/extra">-Extra Pokémon Types</a></li>
+				<li><a href="/card/dex/trainers">Trainer Cards</a></li>
+				<li><a href="/card/dex/energy">Energy Cards</a></li>
+				<li><a href="/card/dex/extra/altart.shtml">Alternate Art Cards</a></li>
+				<li><a href="/card/raidbattles">Raid Battles</a></li>
+				<li><a href="/card/classic/">Pokémon TCG Classic</a></li>
+				<li><a href="/card/english.shtml"><b>English Sets</b></a></li>
+				<li><a href="/card/perfectorder/">-Perfect Order</a></li>
+				<li><a href="/card/ascendedheroes/">-Ascended Heroes</a></li>
+				<li><a href="/card/phantasmalflames/">-Phantasmal Flames</a></li>
+				<li><a href="/card/megaevolution/">-Mega Evolution</a></li>
+				<li><a href="/card/blackbolt/">-Black Bolt</a></li>
+				<li><a href="/card/whiteflare/">-White Flare</a></li>
+				<li><a href="/card/destinedrivals/">-Destined Rivals</a></li>
+				<li><a href="/card/journeytogether/">-Journey Together</a></li>
+				<li><a href="/card/prismaticevolutions/">-Prismatic Evolutions</a></li>
+				<li><a href="/card/surgingsparks/">-Surging Sparks</a></li>
+				<li><a href="/card/stellarcrown/">-Stellar Crown</a></li>
+				<li><a href="/card/shroudedfable/">-Shrouded Fable</a></li>
+				<li><a href="/card/twilightmasquerade/">-Twilight Masquerade</a></li>
+				<li><a href="/card/temporalforces/">-Temporal Forces</a></li>
+				<li><a href="/card/paldeanfates/">-Paldean Fates</a></li>
+				<li><a href="/card/paradoxrift/">-Paradox Rift</a></li>
+				<li><a href="/card/151/">-151</a></li>
+				<li><a href="/card/obsidianflames/">-Obsidian Flames</a></li>
+				<li><a href="/card/paldeaevolved/">-Paldea Evolved</a></li>
+				<li><a href="/card/scarletviolet/">-Scarlet Violet</a></li>
+				<li><a href="/card/swsh.shtml">-SWSH Series</a></li>
+				<li><a href="/card/sm.shtml">-SM Series</a></li>
+				<li><a href="/card/xy.shtml">-XY Series</a></li>
+				<li><a href="/card/bw.shtml">-BW Series</a></li>
+				<li><a href="/card/dpt.shtml">-DPtHS Series</a></li>
+				<li><a href="/card/ex.shtml">-EX Series</a></li>
+				<li><a href="/card/neo.shtml">-Neo/eSeries</a></li>
+				<li><a href="/card/first.shtml">-First Gen Series</a></li>
+				<li><a href="/card/engpromo.shtml"><b>English Promos</b></a></li>
+				<li><a href="/card/megapromos">-Mega Promos</a></li>
+				<li><a href="/card/svpromos">-SV Promos</a></li>
+				<li><a href="/card/swshpromos">-SWSH Promos</a></li>
+				<li><a href="/card/smpromos">-SM Promos</a></li>
+				<li><a href="/card/xypromos">-XY Promos</a></li>
+				<li><a href="/card/popseries.shtml">-POP Series</a></li>
+				<li><a href="/card/japanese.shtml"><b>Japanese Sets</b></a></li>
+				<li><a href="/card/ninjaspinner/">-Ninja Spinner</a></li>
+				<li><a href="/card/nihilzero/">-Nihil Zero</a></li>
+				<li><a href="/card/megadreamex/">-Mega Dream ex</a></li>
+				<li><a href="/card/infernox/">-Inferno X</a></li>
+				<li><a href="/card/megabrave/">-Mega Brave</a></li>
+				<li><a href="/card/megasymphonia/">-Mega Symphonia</a></li>
+				<li><a href="/card/blackbolt-jp/">-Black Bolt</a></li>
+				<li><a href="/card/whiteflare-jp/">-White Flare</a></li>
+				<li><a href="/card/gloryofteamrocket/">-Glory of Team Rocket</a></li>
+				<li><a href="/card/hotairarena/">-Hot Air Arena</a></li>
+				<li><a href="/card/battlepartners/">-Battle Partners</a></li>
+				<li><a href="/card/terastalfestivalex/">-Terastal Festival ex</a></li>
+				<li><a href="/card/superelectricbreaker/">-Super Electric Breaker</a></li>
+				<li><a href="/card/paradisedragona/">-Paradise Dragona</a></li>
+				<li><a href="/card/stellarmiracle/">-Stellar Miracle</a></li>
+				<li><a href="/card/nightwanderer/">-Night Wanderer</a></li>
+				<li><a href="/card/maskofchange/">-Mask of Change</a></li>
+				<li><a href="/card/crimsonhaze/">-Crimson Haze</a></li>
+				<li><a href="/card/wildforce/">-Wild Force</a></li>
+				<li><a href="/card/cyberjudge/">-Cyber Judge</a></li>
+				<li><a href="/card/vstaruniverse/">-VSTAR Universe</a></li>
+				<li><a href="/card/vs">-Pokémon VS</a></li>
+				<li><a href="/card/jppromo.shtml"><b>Japanese Promos</b></a></li>
+				<li><a href="/card/svpromo">-SV Promos</a></li>
+				<li><a href="/card/spromo">-S Promos</a></li>
+				<li><a href="/card/smpromo">-SM Promos</a></li>
+
+			</ul>
+		</li>
+	</ul>
+</nav>
+
+
+<script type="text/javascript">
+
+function loadMobileLbar(){
+	var tbar_lbar_open=document.getElementById('tbar_lbar_open'),
+		tbar_backdrop=document.getElementById('tbar_backdrop'),
+		lbar=document.getElementById('lbar'),
+		lbarLIs=document.querySelectorAll("#lbar_ul>li .navheader"),
+		lbarLIULs=document.querySelectorAll("#lbar_ul>li>ul");
+
+	/* lbar display/hide */
+	tbar_lbar_open.onclick=function() {
+		if (lbar.className.indexOf("show") > -1){//hide
+			lbar.className = lbar.className.replace("show","");
+			bodyRemoveClass("nav_modal");
+		} else{//show
+			lbar.classList.add("show");
+			bodyAddClass("nav_modal");
+		}
+
+		return false;
+	}
+
+
+	/* background clicked when bar shown */
+	tbar_backdrop.onclick=function() {// if the backdrop is clicked, hide menus
+		lbar.className = lbar.className.replace("show","");
+		rbar.className = rbar.className.replace("show","");
+		bodyRemoveClass("nav_modal");
+		return false;
+	}
+
+	/* handle expand/collapse sub-menus in lbar by attaching click events */
+	for(i=0; i<lbarLIs.length; i++){
+		lbarLIs[i].onclick=function(i) {
+			var elem=this.parentNode.getElementsByTagName("UL")[0];
+			var elemDisp=(elem.className.indexOf("show") === -1)
+
+			// hide all ul, then open one if clicked
+			for(i2=0; i2<lbarLIULs.length; i2++){
+				lbarLIULs[i2].className = lbarLIULs[i2].className.replace("show","");
+			}
+
+			if(elemDisp){
+				elem.classList.add("show");
+			}
+
+			return false;
+		}
+	}
+}
+function loadMobileRbar(){
+	var tbar_rbar_open=document.getElementById('tbar_rbar_open'),
+		rbar=document.getElementById('rbar');
+
+	/* rbar display/hide */
+	tbar_rbar_open.onclick=function() {
+		if (rbar.className.indexOf("show") > -1){//hide
+			rbar.className = rbar.className.replace("show","");
+			bodyRemoveClass("nav_modal");
+		} else{//show
+			rbar.classList.add("show");
+			bodyAddClass("nav_modal");
+		}
+
+		return false;
+	}
+}
+
+loadMobileLbar();
+
+/* attach listener to for rbar events AFTER page loads (because #rbar hasn't loaded at this point in page ) */
+if(window.addEventListener){
+	window.addEventListener('load', loadMobileRbar)
+} else{
+	window.attachEvent('onload', loadMobileRbar)
+}
+</script>
+
+
+
+<div id="content">
+		<div class="center" style="margin-top:16px;height:100px"><div id="nn_lb1"></div><div id="nn_mobile_lb1"></div></div>
+<main>
+
+
+<div align=center><table align=center width="95%" border="0" cellspacing="0" cellpadding="4">
+<tr>
+<td align="center" width="25%"><FORM NAME="nav">
+ <SELECT NAME="SelectURL" onChange="document.location.href=document.nav.SelectURL.options[document.nav.SelectURL.selectedIndex].value" style="color:#383838; font-size: 8pt; background:#CEBC77" size=1>
+<option value="#">Kanto: 001 - 151</option>
+<option value="/pokedex-champions/venusaur/">003 Venusaur</option>
+<option value="/pokedex-champions/charizard/">006 Charizard</option>
+<option value="/pokedex-champions/blastoise/">009 Blastoise</option>
+<option value="/pokedex-champions/beedrill/">015 Beedrill</option>
+<option value="/pokedex-champions/pidgeot/">018 Pidgeot</option>
+<option value="/pokedex-champions/arbok/">024 Arbok</option>
+<option value="/pokedex-champions/pikachu/">025 Pikachu</option>
+<option value="/pokedex-champions/raichu/">026 Raichu</option>
+<option value="/pokedex-champions/clefable/">036 Clefable</option>
+<option value="/pokedex-champions/ninetales/">038 Ninetales</option>
+<option value="/pokedex-champions/arcanine/">059 Arcanine</option>
+<option value="/pokedex-champions/alakazam/">065 Alakazam</option>
+<option value="/pokedex-champions/machamp/">068 Machamp</option>
+<option value="/pokedex-champions/victreebel/">071 Victreebel</option>
+<option value="/pokedex-champions/slowbro/">080 Slowbro</option>
+<option value="/pokedex-champions/gengar/">094 Gengar</option>
+<option value="/pokedex-champions/kangaskhan/">115 Kangaskhan</option>
+<option value="/pokedex-champions/starmie/">121 Starmie</option>
+<option value="/pokedex-champions/pinsir/">127 Pinsir</option>
+<option value="/pokedex-champions/tauros/">128 Tauros</option>
+<option value="/pokedex-champions/gyarados/">130 Gyarados</option>
+<option value="/pokedex-champions/ditto/">132 Ditto</option>
+<option value="/pokedex-champions/vaporeon/">134 Vaporeon</option>
+<option value="/pokedex-champions/jolteon/">135 Jolteon</option>
+<option value="/pokedex-champions/flareon/">136 Flareon</option>
+<option value="/pokedex-champions/aerodactyl/">142 Aerodactyl</option>
+<option value="/pokedex-champions/snorlax/">143 Snorlax</option>
+<option value="/pokedex-champions/dragonite/">149 Dragonite</option>
+</SELECT> </FORM></td>
+<td align="center" width="20%">
+<FORM NAME="nav2">
+ <SELECT NAME="SelectURL" onChange="document.location.href=document.nav2.SelectURL.options[document.nav2.SelectURL.selectedIndex].value" style="color:#383838; font-size: 8pt; background:#CEBC77" size=1>
+<option value="#">Johto: 152 - 251</option>
+<option value="/pokedex-champions/meganium/">154 Meganium</option>
+<option value="/pokedex-champions/typhlosion/">157 Typhlosion</option>
+<option value="/pokedex-champions/feraligatr/">160 Feraligatr</option>
+<option value="/pokedex-champions/ariados/">168 Ariados</option>
+<option value="/pokedex-champions/ampharos/">181 Ampharos</option>
+<option value="/pokedex-champions/azumarill/">184 Azumarill</option>
+<option value="/pokedex-champions/politoed/">186 Politoed</option>
+<option value="/pokedex-champions/espeon/">196 Espeon</option>
+<option value="/pokedex-champions/umbreon/">197 Umbreon</option>
+<option value="/pokedex-champions/slowking/">199 Slowking</option>
+<option value="/pokedex-champions/forretress/">205 Forretress</option>
+<option value="/pokedex-champions/steelix/">208 Steelix</option>
+<option value="/pokedex-champions/scizor/">212 Scizor</option>
+<option value="/pokedex-champions/heracross/">214 Heracross</option>
+<option value="/pokedex-champions/skarmory/">227 Skarmory</option>
+<option value="/pokedex-champions/houndoom/">229 Houndoom</option>
+<option value="/pokedex-champions/tyranitar/">248 Tyranitar</option>
+</SELECT> </FORM></td>
+<td align="center" width="20%"> <FORM NAME="nav4">
+ <SELECT NAME="SelectURL" onChange="document.location.href=document.nav4.SelectURL.options[document.nav4.SelectURL.selectedIndex].value" style="color:#383838; font-size: 8pt; background:#CEBC77" size=1>
+<option value="#">Hoenn: 252-386</option>
+<option value="/pokedex-champions/pelipper/">279 Pelipper</option>
+<option value="/pokedex-champions/gardevoir/">282 Gardevoir</option>
+<option value="/pokedex-champions/sableye/">302 Sableye</option>
+<option value="/pokedex-champions/aggron/">306 Aggron</option>
+<option value="/pokedex-champions/medicham/">308 Medicham</option>
+<option value="/pokedex-champions/manectric/">310 Manectric</option>
+<option value="/pokedex-champions/sharpedo/">319 Sharpedo</option>
+<option value="/pokedex-champions/camerupt/">323 Camerupt</option>
+<option value="/pokedex-champions/torkoal/">324 Torkoal</option>
+<option value="/pokedex-champions/altaria/">334 Altaria</option>
+<option value="/pokedex-champions/milotic/">350 Milotic</option>
+<option value="/pokedex-champions/castform/">351 Castform</option>
+<option value="/pokedex-champions/banette/">354 Banette</option>
+<option value="/pokedex-champions/chimecho/">358 Chimecho</option>
+<option value="/pokedex-champions/absol/">359 Absol</option>
+<option value="/pokedex-champions/glalie/">362 Glalie</option>
+</SELECT> </FORM></td>
+<td width="20%" align="center"> <FORM NAME="nav5">
+ <SELECT NAME="SelectURL" onChange="document.location.href=document.nav5.SelectURL.options[document.nav5.SelectURL.selectedIndex].value" style="color:#383838; font-size: 8pt; background:#CEBC77" size=1>
+<option value="#">Sinnoh: 387-493</option>
+<option value="/pokedex-champions/torterra/">389 Torterra</option>
+<option value="/pokedex-champions/infernape/">392 Infernape</option>
+<option value="/pokedex-champions/empoleon/">395 Empoleon</option>
+<option value="/pokedex-champions/luxray/">405 Luxray</option>
+<option value="/pokedex-champions/roserade/">407 Roserade</option>
+<option value="/pokedex-champions/rampardos/">409 Rampardos</option>
+<option value="/pokedex-champions/bastiodon/">411 Bastiodon</option>
+<option value="/pokedex-champions/lopunny/">428 Lopunny</option>
+<option value="/pokedex-champions/spiritomb/">442 Spiritomb</option>
+<option value="/pokedex-champions/garchomp/">445 Garchomp</option>
+<option value="/pokedex-champions/lucario/">448 Lucario</option>
+<option value="/pokedex-champions/hippowdon/">450 Hippowdon</option>
+<option value="/pokedex-champions/toxicroak/">454 Toxicroak</option>
+<option value="/pokedex-champions/abomasnow/">460 Abomasnow</option>
+<option value="/pokedex-champions/weavile/">461 Weavile</option>
+<option value="/pokedex-champions/rhyperior/">464 Rhyperior</option>
+<option value="/pokedex-champions/leafeon/">470 Leafeon</option>
+<option value="/pokedex-champions/glaceon/">471 Glaceon</option>
+<option value="/pokedex-champions/gliscor/">472 Gliscor</option>
+<option value="/pokedex-champions/mamoswine/">473 Mamoswine</option>
+<option value="/pokedex-champions/gallade/">475 Gallade</option>
+<option value="/pokedex-champions/froslass/">478 Froslass</option>
+<option value="/pokedex-champions/rotom/">479 Rotom</option>
+</SELECT> </FORM></td>
+<td width="20%" align="center"> <FORM NAME="nav6">
+ <SELECT NAME="SelectURL" onChange="document.location.href=document.nav6.SelectURL.options[document.nav6.SelectURL.selectedIndex].value" style="color:#383838; font-size: 8pt; background:#CEBC77" size=1>
+<option value="#">Unova: 494-649</option>
+<option value="/pokedex-champions/serperior/">497 Serperior</option>
+<option value="/pokedex-champions/emboar/">500 Emboar</option>
+<option value="/pokedex-champions/samurott/">503 Samurott</option>
+<option value="/pokedex-champions/watchog/">505 Watchog</option>
+<option value="/pokedex-champions/liepard/">510 Liepard</option>
+<option value="/pokedex-champions/simisage/">512 Simisage</option>
+<option value="/pokedex-champions/simisear/">514 Simisear</option>
+<option value="/pokedex-champions/simipour/">516 Simipour</option>
+<option value="/pokedex-champions/excadrill/">530 Excadrill</option>
+<option value="/pokedex-champions/audino/">531 Audino</option>
+<option value="/pokedex-champions/conkeldurr/">534 Conkeldurr</option>
+<option value="/pokedex-champions/whimsicott/">547 Whimsicott</option>
+<option value="/pokedex-champions/krookodile/">553 Krookodile</option>
+<option value="/pokedex-champions/cofagrigus/">563 Cofagrigus</option>
+<option value="/pokedex-champions/garbodor/">569 Garbodor</option>
+<option value="/pokedex-champions/zoroark/">571 Zoroark</option>
+<option value="/pokedex-champions/reuniclus/">579 Reuniclus</option>
+<option value="/pokedex-champions/vanilluxe/">584 Vanilluxe</option>
+<option value="/pokedex-champions/emolga/">587 Emolga</option>
+<option value="/pokedex-champions/chandelure/">609 Chandelure</option>
+<option value="/pokedex-champions/beartic/">614 Beartic</option>
+<option value="/pokedex-champions/stunfisk/">618 Stunfisk</option>
+<option value="/pokedex-champions/golurk/">623 Golurk</option>
+<option value="/pokedex-champions/hydreigon/">635 Hydreigon</option>
+<option value="/pokedex-champions/volcarona/">637 Volcarona</option>
+</SELECT> </FORM></td></tr><tr>
+<td width="20%" align="center"> <FORM NAME="nav7">
+ <SELECT NAME="SelectURL" onChange="document.location.href=document.nav7.SelectURL.options[document.nav7.SelectURL.selectedIndex].value" style="color:#383838; font-size: 8pt; background:#CEBC77" size=1>
+<option value="#">Kalos: 650-721</option>
+<option value="/pokedex-champions/chesnaught/">652 Chesnaught</option>
+<option value="/pokedex-champions/delphox/">655 Delphox</option>
+<option value="/pokedex-champions/greninja/">658 Greninja</option>
+<option value="/pokedex-champions/diggersby/">660 Diggersby</option>
+<option value="/pokedex-champions/talonflame/">663 Talonflame</option>
+<option value="/pokedex-champions/vivillon/">666 Vivillon</option>
+<option value="/pokedex-champions/floette/">670 Floette</option>
+<option value="/pokedex-champions/florges/">671 Florges</option>
+<option value="/pokedex-champions/pangoro/">675 Pangoro</option>
+<option value="/pokedex-champions/furfrou/">676 Furfrou</option>
+<option value="/pokedex-champions/meowstic/">678 Meowstic</option>
+<option value="/pokedex-champions/aegislash/">681 Aegislash</option>
+<option value="/pokedex-champions/aromatisse/">683 Aromatisse</option>
+<option value="/pokedex-champions/slurpuff/">685 Slurpuff</option>
+<option value="/pokedex-champions/clawitzer/">693 Clawitzer</option>
+<option value="/pokedex-champions/heliolisk/">695 Heliolisk</option>
+<option value="/pokedex-champions/tyrantrum/">697 Tyrantrum</option>
+<option value="/pokedex-champions/aurorus/">699 Aurorus</option>
+<option value="/pokedex-champions/sylveon/">700 Sylveon</option>
+<option value="/pokedex-champions/hawlucha/">701 Hawlucha</option>
+<option value="/pokedex-champions/dedenne/">702 Dedenne</option>
+<option value="/pokedex-champions/goodra/">706 Goodra</option>
+<option value="/pokedex-champions/klefki/">707 Klefki</option>
+<option value="/pokedex-champions/trevenant/">709 Trevenant</option>
+<option value="/pokedex-champions/gourgeist/">711 Gourgeist</option>
+<option value="/pokedex-champions/avalugg/">713 Avalugg</option>
+<option value="/pokedex-champions/noivern/">715 Noivern</option>
+</SELECT> </FORM></td><td width="20%" align="center"> <FORM NAME="nav8">
+ <SELECT NAME="SelectURL" onChange="document.location.href=document.nav8.SelectURL.options[document.nav8.SelectURL.selectedIndex].value" style="color:#383838; font-size: 8pt; background:#CEBC77" size=1>
+<option value="#">Alola: 722-809</option>
+<option value="/pokedex-champions/decidueye/">724 Decidueye</option>
+<option value="/pokedex-champions/incineroar/">727 Incineroar</option>
+<option value="/pokedex-champions/primarina/">730 Primarina</option>
+<option value="/pokedex-champions/toucannon/">733 Toucannon</option>
+<option value="/pokedex-champions/crabominable/">740 Crabominable</option>
+<option value="/pokedex-champions/lycanroc/">745 Lycanroc</option>
+<option value="/pokedex-champions/toxapex/">748 Toxapex</option>
+<option value="/pokedex-champions/mudsdale/">750 Mudsdale</option>
+<option value="/pokedex-champions/araquanid/">752 Araquanid</option>
+<option value="/pokedex-champions/salazzle/">758 Salazzle</option>
+<option value="/pokedex-champions/tsareena/">763 Tsareena</option>
+<option value="/pokedex-champions/oranguru/">765 Oranguru</option>
+<option value="/pokedex-champions/passimian/">766 Passimian</option>
+<option value="/pokedex-champions/mimikyu/">778 Mimikyu</option>
+<option value="/pokedex-champions/drampa/">780 Drampa</option>
+<option value="/pokedex-champions/kommo-o/">784 Kommo-o</option>
+</SELECT> </FORM></td><td width="20%" align="center"> <FORM NAME="nav9">
+ <SELECT NAME="SelectURL" onChange="document.location.href=document.nav9.SelectURL.options[document.nav9.SelectURL.selectedIndex].value" style="color:#383838; font-size: 8pt; background:#CEBC77" size=1>
+<option value="#">Galar/Hisui: 810-905</option>
+<option value="/pokedex-champions/corviknight/">823 Corviknight</option>
+<option value="/pokedex-champions/flapple/">841 Flapple</option>
+<option value="/pokedex-champions/appletun/">842 Appletun</option>
+<option value="/pokedex-champions/sandaconda/">844 Sandaconda</option>
+<option value="/pokedex-champions/polteageist/">855 Polteageist</option>
+<option value="/pokedex-champions/hatterene/">858 Hatterene</option>
+<option value="/pokedex-champions/mr.rime/">866 Mr. Rime</option>
+<option value="/pokedex-champions/runerigus/">867 Runerigus</option>
+<option value="/pokedex-champions/alcremie/">869 Alcremie</option>
+<option value="/pokedex-champions/morpeko/">877 Morpeko</option>
+<option value="/pokedex-champions/dragapult/">887 Dragapult</option>
+<option value="/pokedex-champions/wyrdeer/">899 Wyrdeer</option>
+<option value="/pokedex-champions/kleavor/">900 Kleavor</option>
+<option value="/pokedex-champions/basculegion/">902 Basculegion</option>
+<option value="/pokedex-champions/sneasler/">903 Sneasler</option>
+</SELECT> </FORM></td><td width="20%" align="center"> <FORM NAME="nav10">
+ <SELECT NAME="SelectURL" onChange="document.location.href=document.nav10.SelectURL.options[document.nav10.SelectURL.selectedIndex].value" style="color:#383838; font-size: 8pt; background:#CEBC77" size=1>
+<option value="#">Paldea: 906-1025</option>
+<option value="/pokedex-champions/meowscarada/">908 Meowscarada</option>
+<option value="/pokedex-champions/skeledirge/">911 Skeledirge</option>
+<option value="/pokedex-champions/quaquaval/">914 Quaquaval</option>
+<option value="/pokedex-champions/maushold/">925 Maushold</option>
+<option value="/pokedex-champions/garganacl/">934 Garganacl</option>
+<option value="/pokedex-champions/armarouge/">936 Armarouge</option>
+<option value="/pokedex-champions/ceruledge/">937 Ceruledge</option>
+<option value="/pokedex-champions/bellibolt/">939 Bellibolt</option>
+<option value="/pokedex-champions/scovillain/">952 Scovillain</option>
+<option value="/pokedex-champions/espathra/">956 Espathra</option>
+<option value="/pokedex-champions/tinkaton/">959 Tinkaton</option>
+<option value="/pokedex-champions/palafin/">964 Palafin</option>
+<option value="/pokedex-champions/orthworm/">968 Orthworm</option>
+<option value="/pokedex-champions/glimmora/">970 Glimmora</option>
+<option value="/pokedex-champions/farigiraf/">981 Farigiraf</option>
+<option value="/pokedex-champions/kingambit/">983 Kingambit</option>
+<option value="/pokedex-champions/sinistcha/">1013 Sinistcha</option>
+<option value="/pokedex-champions/archaludon/">1018 Archaludon</option>
+<option value="/pokedex-champions/hydrapple/">1019 Hydrapple</option>
+
+
+
+
+</SELECT> </FORM></td></tr></table><table align=center width="95%" border="0" cellspacing="0" cellpadding="4">
+<tr>
+<td colspan="2" align="center"> <FORM NAME="cent">
+ <SELECT NAME="SelectURL" onChange="document.location.href=document.cent.SelectURL.options[document.cent.SelectURL.selectedIndex].value" style="color:#383838; font-size: 8pt; background:#CEBC77" size=1>
+ <option value="#">Pok&eacute;dex: A - G</option>
+<option value="/pokedex-champions/abomasnow/">Abomasnow</option>
+<option value="/pokedex-champions/absol/">Absol</option>
+<option value="/pokedex-champions/aegislash/">Aegislash</option>
+<option value="/pokedex-champions/aerodactyl/">Aerodactyl</option>
+<option value="/pokedex-champions/aggron/">Aggron</option>
+<option value="/pokedex-champions/alakazam/">Alakazam</option>
+<option value="/pokedex-champions/alcremie/">Alcremie</option>
+<option value="/pokedex-champions/altaria/">Altaria</option>
+<option value="/pokedex-champions/ampharos/">Ampharos</option>
+<option value="/pokedex-champions/appletun/">Appletun</option>
+<option value="/pokedex-champions/araquanid/">Araquanid</option>
+<option value="/pokedex-champions/arbok/">Arbok</option>
+<option value="/pokedex-champions/arcanine/">Arcanine</option>
+<option value="/pokedex-champions/archaludon/">Archaludon</option>
+<option value="/pokedex-champions/ariados/">Ariados</option>
+<option value="/pokedex-champions/armarouge/">Armarouge</option>
+<option value="/pokedex-champions/aromatisse/">Aromatisse</option>
+<option value="/pokedex-champions/audino/">Audino</option>
+<option value="/pokedex-champions/aurorus/">Aurorus</option>
+<option value="/pokedex-champions/avalugg/">Avalugg</option>
+<option value="/pokedex-champions/azumarill/">Azumarill</option>
+<option value="/pokedex-champions/banette/">Banette</option>
+<option value="/pokedex-champions/basculegion/">Basculegion</option>
+<option value="/pokedex-champions/bastiodon/">Bastiodon</option>
+<option value="/pokedex-champions/beartic/">Beartic</option>
+<option value="/pokedex-champions/beedrill/">Beedrill</option>
+<option value="/pokedex-champions/bellibolt/">Bellibolt</option>
+<option value="/pokedex-champions/blastoise/">Blastoise</option>
+<option value="/pokedex-champions/camerupt/">Camerupt</option>
+<option value="/pokedex-champions/castform/">Castform</option>
+<option value="/pokedex-champions/ceruledge/">Ceruledge</option>
+<option value="/pokedex-champions/chandelure/">Chandelure</option>
+<option value="/pokedex-champions/charizard/">Charizard</option>
+<option value="/pokedex-champions/chesnaught/">Chesnaught</option>
+<option value="/pokedex-champions/chimecho/">Chimecho</option>
+<option value="/pokedex-champions/clawitzer/">Clawitzer</option>
+<option value="/pokedex-champions/clefable/">Clefable</option>
+<option value="/pokedex-champions/cofagrigus/">Cofagrigus</option>
+<option value="/pokedex-champions/conkeldurr/">Conkeldurr</option>
+<option value="/pokedex-champions/corviknight/">Corviknight</option>
+<option value="/pokedex-champions/crabominable/">Crabominable</option>
+<option value="/pokedex-champions/decidueye/">Decidueye</option>
+<option value="/pokedex-champions/dedenne/">Dedenne</option>
+<option value="/pokedex-champions/delphox/">Delphox</option>
+<option value="/pokedex-champions/diggersby/">Diggersby</option>
+<option value="/pokedex-champions/ditto/">Ditto</option>
+<option value="/pokedex-champions/dragapult/">Dragapult</option>
+<option value="/pokedex-champions/dragonite/">Dragonite</option>
+<option value="/pokedex-champions/drampa/">Drampa</option>
+<option value="/pokedex-champions/emboar/">Emboar</option>
+<option value="/pokedex-champions/emolga/">Emolga</option>
+<option value="/pokedex-champions/empoleon/">Empoleon</option>
+<option value="/pokedex-champions/espathra/">Espathra</option>
+<option value="/pokedex-champions/espeon/">Espeon</option>
+<option value="/pokedex-champions/excadrill/">Excadrill</option>
+<option value="/pokedex-champions/farigiraf/">Farigiraf</option>
+<option value="/pokedex-champions/feraligatr/">Feraligatr</option>
+<option value="/pokedex-champions/flapple/">Flapple</option>
+<option value="/pokedex-champions/flareon/">Flareon</option>
+<option value="/pokedex-champions/floette/">Floette</option>
+<option value="/pokedex-champions/florges/">Florges</option>
+<option value="/pokedex-champions/forretress/">Forretress</option>
+<option value="/pokedex-champions/froslass/">Froslass</option>
+<option value="/pokedex-champions/furfrou/">Furfrou</option>
+<option value="/pokedex-champions/gallade/">Gallade</option>
+<option value="/pokedex-champions/garbodor/">Garbodor</option>
+<option value="/pokedex-champions/garchomp/">Garchomp</option>
+<option value="/pokedex-champions/gardevoir/">Gardevoir</option>
+<option value="/pokedex-champions/garganacl/">Garganacl</option>
+<option value="/pokedex-champions/gengar/">Gengar</option>
+<option value="/pokedex-champions/glaceon/">Glaceon</option>
+<option value="/pokedex-champions/glalie/">Glalie</option>
+<option value="/pokedex-champions/glimmora/">Glimmora</option>
+<option value="/pokedex-champions/gliscor/">Gliscor</option>
+<option value="/pokedex-champions/golurk/">Golurk</option>
+<option value="/pokedex-champions/goodra/">Goodra</option>
+<option value="/pokedex-champions/gourgeist/">Gourgeist</option>
+<option value="/pokedex-champions/greninja/">Greninja</option>
+<option value="/pokedex-champions/gyarados/">Gyarados</option>
+</SELECT> </FORM></td>
+<td colspan="2" align="center"> <FORM NAME="coast">
+ <SELECT NAME="SelectURL" onChange="document.location.href=document.coast.SelectURL.options[document.coast.SelectURL.selectedIndex].value" style="color:#383838; font-size: 8pt; background:#CEBC77" size=1>
+ <option value="#">Pok&eacute;dex: H - R</option>
+
+<option value="/pokedex-champions/hatterene/">Hatterene</option>
+<option value="/pokedex-champions/hawlucha/">Hawlucha</option>
+<option value="/pokedex-champions/heliolisk/">Heliolisk</option>
+<option value="/pokedex-champions/heracross/">Heracross</option>
+<option value="/pokedex-champions/hippowdon/">Hippowdon</option>
+<option value="/pokedex-champions/houndoom/">Houndoom</option>
+<option value="/pokedex-champions/hydrapple/">Hydrapple</option>
+<option value="/pokedex-champions/hydreigon/">Hydreigon</option>
+<option value="/pokedex-champions/incineroar/">Incineroar</option>
+<option value="/pokedex-champions/infernape/">Infernape</option>
+<option value="/pokedex-champions/jolteon/">Jolteon</option>
+<option value="/pokedex-champions/kangaskhan/">Kangaskhan</option>
+<option value="/pokedex-champions/kingambit/">Kingambit</option>
+<option value="/pokedex-champions/kleavor/">Kleavor</option>
+<option value="/pokedex-champions/klefki/">Klefki</option>
+<option value="/pokedex-champions/kommo-o/">Kommo-o</option>
+<option value="/pokedex-champions/krookodile/">Krookodile</option>
+<option value="/pokedex-champions/leafeon/">Leafeon</option>
+<option value="/pokedex-champions/liepard/">Liepard</option>
+<option value="/pokedex-champions/lopunny/">Lopunny</option>
+<option value="/pokedex-champions/lucario/">Lucario</option>
+<option value="/pokedex-champions/luxray/">Luxray</option>
+<option value="/pokedex-champions/lycanroc/">Lycanroc</option>
+<option value="/pokedex-champions/machamp/">Machamp</option>
+<option value="/pokedex-champions/mamoswine/">Mamoswine</option>
+<option value="/pokedex-champions/manectric/">Manectric</option>
+<option value="/pokedex-champions/maushold/">Maushold</option>
+<option value="/pokedex-champions/medicham/">Medicham</option>
+<option value="/pokedex-champions/meganium/">Meganium</option>
+<option value="/pokedex-champions/meowscarada/">Meowscarada</option>
+<option value="/pokedex-champions/meowstic/">Meowstic</option>
+<option value="/pokedex-champions/milotic/">Milotic</option>
+<option value="/pokedex-champions/mimikyu/">Mimikyu</option>
+<option value="/pokedex-champions/morpeko/">Morpeko</option>
+<option value="/pokedex-champions/mr.rime/">Mr. Rime</option>
+<option value="/pokedex-champions/mudsdale/">Mudsdale</option>
+<option value="/pokedex-champions/ninetales/">Ninetales</option>
+<option value="/pokedex-champions/noivern/">Noivern</option>
+<option value="/pokedex-champions/oranguru/">Oranguru</option>
+<option value="/pokedex-champions/orthworm/">Orthworm</option>
+<option value="/pokedex-champions/palafin/">Palafin</option>
+<option value="/pokedex-champions/pangoro/">Pangoro</option>
+<option value="/pokedex-champions/passimian/">Passimian</option>
+<option value="/pokedex-champions/pelipper/">Pelipper</option>
+<option value="/pokedex-champions/pidgeot/">Pidgeot</option>
+<option value="/pokedex-champions/pikachu/">Pikachu</option>
+<option value="/pokedex-champions/pinsir/">Pinsir</option>
+<option value="/pokedex-champions/politoed/">Politoed</option>
+<option value="/pokedex-champions/polteageist/">Polteageist</option>
+<option value="/pokedex-champions/primarina/">Primarina</option>
+<option value="/pokedex-champions/quaquaval/">Quaquaval</option>
+<option value="/pokedex-champions/raichu/">Raichu</option>
+<option value="/pokedex-champions/rampardos/">Rampardos</option>
+<option value="/pokedex-champions/reuniclus/">Reuniclus</option>
+<option value="/pokedex-champions/rhyperior/">Rhyperior</option>
+<option value="/pokedex-champions/roserade/">Roserade</option>
+<option value="/pokedex-champions/rotom/">Rotom</option>
+<option value="/pokedex-champions/runerigus/">Runerigus</option>
+</SELECT> </FORM></td>
+<td colspan="2" align="center"> <FORM NAME="mount">
+ <SELECT NAME="SelectURL" onChange="document.location.href=document.mount.SelectURL.options[document.mount.SelectURL.selectedIndex].value" style="color:#383838; font-size: 8pt; background:#CEBC77" size=1>
+ <option value="#">Pok&eacute;dex: S - Z</option>
+<option value="/pokedex-champions/sableye/">Sableye</option>
+<option value="/pokedex-champions/salazzle/">Salazzle</option>
+<option value="/pokedex-champions/samurott/">Samurott</option>
+<option value="/pokedex-champions/sandaconda/">Sandaconda</option>
+<option value="/pokedex-champions/scizor/">Scizor</option>
+<option value="/pokedex-champions/scovillain/">Scovillain</option>
+<option value="/pokedex-champions/serperior/">Serperior</option>
+<option value="/pokedex-champions/sharpedo/">Sharpedo</option>
+<option value="/pokedex-champions/simipour/">Simipour</option>
+<option value="/pokedex-champions/simisage/">Simisage</option>
+<option value="/pokedex-champions/simisear/">Simisear</option>
+<option value="/pokedex-champions/sinistcha/">Sinistcha</option>
+<option value="/pokedex-champions/skarmory/">Skarmory</option>
+<option value="/pokedex-champions/skeledirge/">Skeledirge</option>
+<option value="/pokedex-champions/slowbro/">Slowbro</option>
+<option value="/pokedex-champions/slowking/">Slowking</option>
+<option value="/pokedex-champions/slurpuff/">Slurpuff</option>
+<option value="/pokedex-champions/sneasler/">Sneasler</option>
+<option value="/pokedex-champions/snorlax/">Snorlax</option>
+<option value="/pokedex-champions/spiritomb/">Spiritomb</option>
+<option value="/pokedex-champions/starmie/">Starmie</option>
+<option value="/pokedex-champions/steelix/">Steelix</option>
+<option value="/pokedex-champions/stunfisk/">Stunfisk</option>
+<option value="/pokedex-champions/sylveon/">Sylveon</option>
+<option value="/pokedex-champions/talonflame/">Talonflame</option>
+<option value="/pokedex-champions/tauros/">Tauros</option>
+<option value="/pokedex-champions/tinkaton/">Tinkaton</option>
+<option value="/pokedex-champions/torkoal/">Torkoal</option>
+<option value="/pokedex-champions/torterra/">Torterra</option>
+<option value="/pokedex-champions/toucannon/">Toucannon</option>
+<option value="/pokedex-champions/toxapex/">Toxapex</option>
+<option value="/pokedex-champions/toxicroak/">Toxicroak</option>
+<option value="/pokedex-champions/trevenant/">Trevenant</option>
+<option value="/pokedex-champions/tsareena/">Tsareena</option>
+<option value="/pokedex-champions/typhlosion/">Typhlosion</option>
+<option value="/pokedex-champions/tyranitar/">Tyranitar</option>
+<option value="/pokedex-champions/tyrantrum/">Tyrantrum</option>
+<option value="/pokedex-champions/umbreon/">Umbreon</option>
+<option value="/pokedex-champions/vanilluxe/">Vanilluxe</option>
+<option value="/pokedex-champions/vaporeon/">Vaporeon</option>
+<option value="/pokedex-champions/venusaur/">Venusaur</option>
+<option value="/pokedex-champions/victreebel/">Victreebel</option>
+<option value="/pokedex-champions/vivillon/">Vivillon</option>
+<option value="/pokedex-champions/volcarona/">Volcarona</option>
+<option value="/pokedex-champions/watchog/">Watchog</option>
+<option value="/pokedex-champions/weavile/">Weavile</option>
+<option value="/pokedex-champions/whimsicott/">Whimsicott</option>
+<option value="/pokedex-champions/wyrdeer/">Wyrdeer</option>
+<option value="/pokedex-champions/zoroark/">Zoroark</option>
+<option value="/pokedex-champions//"></option>
+
+</SELECT> </FORM></td>
+
+</tr></table></div>
+
+
+
+<div align="center"><table class="dextab">
+  <tr>
+    <td width="65%"><table  width="100%" border="0" cellspacing="0" cellpadding="0">
+  		<tr>
+    		<td width="32" align="center"><img src="/pokedex-champions/icon/006.png"></td>
+		<td><h1>&nbsp;#006 Charizard</h1></td></tr></table></td>
+    <td class="footop"><a href="#general">General</a></td>
+    <td class="footop"><a href="#location">Location</a></td>
+    <td class="footop"><a href="#attacks">Attacks</a></td>
+    <td class="footop"><a href="#stats">Stats</a></td>
+    <td class="footop"><a href="egg.shtml">Egg Moves</a></td>
+
+  </tr></table>
+<table class="dextab">
+      <tr ><td width="20%" class="pkmn"><a href="/pokedex-sv/charizard">Gen IX Dex</a></td>	<td width="20%" class="pkmn"><a href="/pokedex-swsh/charizard/">Gen VIII Dex</a></td>	<td width="20%" class="pkmn"><a href="/pokedex-sm/006.shtml">Gen VII Dex</a></td>	<td width="20%" class="pkmn"><a href="/pokedex-xy/006.shtml">Gen VI Dex</a></td>	<td width="20%" class="pkmn"><a href="/pokedex-bw/006.shtml">Gen V Dex</a></td></tr><tr>	<td width="20%" class="pkmn"><a href="/pokedex-dp/006.shtml">Gen IV Dex</a></td>	<td width="20%" class="pkmn"><a href="/pokedex-rs/006.shtml">Gen III Dex</a></td>	<td width="20%" class="pkmn"><a href="/pokedex-gs/006.shtml">Gen II Dex</a></td>	<td width="20%" class="pkmn"><a href="/pokedex/006.shtml">Gen I Dex</a></td>  </tr>
+<tr>
+<td class="curr" colspan="5"><a href="/pokedex-champions/charizard">Champions Pok&eacute;dex</a></td></tr></table><p><a name="general"></a><table class="dextable">
+		<tr>
+			<td class="fooevo">Picture</td>
+		</tr>
+		<tr>
+			<td class="fooinfo" align="center"><table align="center"><tr><td class="pkmn"><img src="/pokemonhome/pokemon/006.png" loading="lazy" alt="Normal Sprite" style="height:250px" /></td><td class="pkmn"><img src="/Shiny/home/006.png" loading="lazy" alt="Shiny Sprite" style="height:250px" /></td></tr></table></td></table><table class="dextable">
+		<tr>
+			<td class="fooevo">Name</td>
+			<td class="fooevo">Other Names</td>
+			<td class="fooevo">No.</td>
+			<td class="fooevo">Gender Ratio</td>
+			<td class="fooevo">Type</td>
+		</tr>
+		<tr>
+
+			<td class="fooinfo">Charizard</td>
+			<td class="fooinfo"><table width="120" cellspacing="0" cellpadding="0">
+			<tr> <td><b>Japan</b>: </td><td>Lizardon<br />&#12522;&#12470;&#12540;&#12489;&#12531;</td></tr>
+			<tr> <td><b>French</b>: </td><td>Dracaufeu</td></tr>
+			<tr> <td><b>German</b>: </td><td>Glurak</td></tr>
+			<tr> <td><b>Korean</b>: </td><td>&#47532;&#51088;&#47805;</td></tr>
+			</table></td>
+			<td class="fooinfo"><table width="120" cellspacing="0" cellpadding="0"><tr> <td><b>National</b>: </td><td>#006</td></tr>
+
+			
+			</table></td>
+			<td class="fooinfo"><table width="120" cellspacing="0" cellpadding="0"><tr> <td>Male <font color="#499FFF">&#9794;</font>:</td><td>88%</td></tr><tr><td>Female <font color="#F6814A">&#9792;</font>:</td><td>12%</td></tr></table></td>
+			<td class="cen"><a href="/pokedex-champions/fire.shtml"><img src="/pokedex-bw/type/fire.gif" loading="lazy" border="0" alt="Fire-type" class="typeimg" /></a> <a href="/pokedex-champions/flying.shtml"><img src="/pokedex-bw/type/flying.gif" loading="lazy"  alt="Flying-type" class="typeimg" /></a></td>
+
+		</tr>
+		<tr>
+			<td class="foo">Classification</td>
+			<td class="foo">Height</td>
+			<td class="foo">Weight</td>
+		</tr>
+		<tr>
+			<td class="fooinfo">Flame Pok&eacute;mon</td>
+			<td class="fooinfo">5'07"<br />
+			1.7m</td>
+			<td class="fooinfo">199.5lbs<br />
+			90.5kg</td>
+		</tr></table>
+		<table class="dextable">		<tr>
+			<td align="left" colspan="6" class="fooleft"><b>Abilities</b>: <a href="/abilitydex/drought.shtml"><b>Drought</b></a> </td>
+		</tr>
+		<tr>
+			<td align="left" colspan="5" class="fooinfo">
+<a href="/abilitydex/drought.shtml"><b>Drought</b></a>: Weather changes to Intense Sunshine when the Pok&eacute;mon enters the battle. As of X & Y, this lasts 5 turns. </td>
+		</tr>
+
+	</table>
+<table class="dextable" style="@media (max-width:1026px) {display:none;}">
+	<tr>
+		<td colspan="18" class="foo">
+		<h2>Weakness</h2>
+		</td>
+	</tr>
+<tr>	
+	<td class="footype">
+		<a href="/attackdex-champions/normal.shtml"><img src="/pokedex-sv/type/icon/normal.png" loading="lazy" alt="Attacking Move Type: Normal-type" title="Attacking Move Type: Normal-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/fire.shtml"><img src="/pokedex-sv/type/icon/fire.png" loading="lazy" alt="Attacking Move Type: Fire-type" title="Attacking Move Type: Fire-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/water.shtml"><img src="/pokedex-sv/type/icon/water.png" loading="lazy" alt="Attacking Move Type: Water-type" title="Attacking Move Type: Water-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/electric.shtml"><img src="/pokedex-sv/type/icon/electric.png" loading="lazy" alt="Attacking Move Type: Electric-type" title="Attacking Move Type: Electric-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/grass.shtml"><img src="/pokedex-sv/type/icon/grass.png" loading="lazy" alt="Attacking Move Type: Grass-type" title="Attacking Move Type: Grass-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/ice.shtml"><img src="/pokedex-sv/type/icon/ice.png" loading="lazy" alt="Attacking Move Type: Ice-type" title="Attacking Move Type: Ice-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/fighting.shtml"><img src="/pokedex-sv/type/icon/fighting.png" loading="lazy" alt="Attacking Move Type: Fighting-type" title="Attacking Move Type: Fighting-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/poison.shtml"><img src="/pokedex-sv/type/icon/poison.png" loading="lazy" alt="Attacking Move Type: Poison-type" title="Attacking Move Type: Poison-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/ground.shtml"><img src="/pokedex-sv/type/icon/ground.png" loading="lazy" alt="Attacking Move Type: Ground-type" title="Attacking Move Type: Ground-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/flying.shtml"><img src="/pokedex-sv/type/icon/flying.png" loading="lazy" alt="Attacking Move Type: Flying-type" title="Attacking Move Type: Flying-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/psychict.shtml"><img src="/pokedex-sv/type/icon/psychic.png" loading="lazy" alt="Attacking Move Type: Psychic-type" title="Attacking Move Type: Psychic-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/bug.shtml"><img src="/pokedex-sv/type/icon/bug.png" loading="lazy" alt="Attacking Move Type: Bug-type" title="Attacking Move Type: Bug-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/rock.shtml"><img src="/pokedex-sv/type/icon/rock.png" loading="lazy" alt="Attacking Move Type: Rock-type" title="Attacking Move Type: Rock-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/ghost.shtml"><img src="/pokedex-sv/type/icon/ghost.png" loading="lazy" alt="Attacking Move Type: Ghost-type" title="Attacking Move Type: Ghost-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/dragon.shtml"><img src="/pokedex-sv/type/icon/dragon.png" loading="lazy" alt="Attacking Move Type: Dragon-type" title="Attacking Move Type: Dragon-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/dark.shtml"><img src="/pokedex-sv/type/icon/dark.png" loading="lazy" alt="Attacking Move Type: Dark-type" title="Attacking Move Type: Dark-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/steel.shtml"><img src="/pokedex-sv/type/icon/steel.png" loading="lazy" alt="Attacking Move Type: Steel-type" title="Attacking Move Type: Steel-type" height="25" /></a>
+		</td>		<td class="footype">
+		<a href="/attackdex-champions/fairy.shtml"><img src="/pokedex-sv/type/icon/fairy.png" loading="lazy" alt="Attacking Move Type: Fairy-type" title="Attacking Move Type: Fairy-type" height="25" /></a>
+		</td>
+</tr>
+<tr>
+			<td class="footype">*1</td>
+			<td class="footype">*0.5</td>
+			<td class="footype">*2</td>
+			<td class="footype">*2</td>
+			<td class="footype">*0.25</td>
+			<td class="footype">*1</td>
+			<td class="footype">*0.5</td>
+			<td class="footype">*1</td>
+			<td class="footype">*0</td>
+			<td class="footype">*1</td>
+			<td class="footype">*1</td>
+			<td class="footype">*0.25</td>
+			<td class="footype">*4</td>
+			<td class="footype">*1</td>
+			<td class="footype">*1</td>
+			<td class="footype">*1</td>
+			<td class="footype">*0.5</td>
+			<td class="footype">*0.5</td>
+		</tr>
+</table>
+
+
+<table class="dextable" align="center">
+		<tr>
+			<td class="fooevo">Evolutionary Chain</td>
+		</tr>
+		<tr>
+			<td class="fooinfo" align="center"><table class="evochain">
+			<tr>			<td rowspan="2" class="pkmn"><a href="/pokedex-champions/mewtwo/"><img src="/legendsz-a/pokemon/006.png"  width="100" loading="lazy" /></a></td>
+			<td ><img src="/pokedex-champions/evoicon/charizarditex.png" title="Level " /></td><td class="pkmn"><a href="/pokedex-champions/mewtwo/"><img src="/legendsz-a/pokemon/006-mx.png"  width="100" loading="lazy" /></a></td></tr>
+			<tr><td ><img src="/pokedex-champions/evoicon/charizarditey.png" title="Level " /></td><td class="pkmn"><a href="/pokedex-champions/mewtwo/"><img src="/legendsz-a/pokemon/006-my.png"  width="100" loading="lazy" /></a></td></tr></table></td>
+		</tr>
+</table>
+
+		<a name="attacks"></a><table class="dextable"><tr ><td colspan="10" class="fooevo"><h3><a name="standardlevel"></a>Standard Moves</h3></td></tr><tr><th class="attheader">Attack Name</th><th class="attheader">Type</th><th class="attheader">Cat.</th><th class="attheader">Att.</th><th class="attheader">Acc.</th><th class="attheader">PP</th><th class="attheader">Effect %</th></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/acrobatics.shtml">Acrobatics</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/flying.gif" loading="lazy" alt="Acrobatics - Flying-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Acrobatics: Physical Move"></td>
+				<td class="cen">55</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">This move's power is doubled if the user isn't holding an item.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/aerialace.shtml">Aerial Ace</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/flying.gif" loading="lazy" alt="Aerial Ace - Flying-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Aerial Ace: Physical Move"></td>
+				<td class="cen">60</td>
+				<td class="cen">101</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">This move never misses.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/aircutter.shtml">Air Cutter</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/flying.gif" loading="lazy" alt="Air Cutter - Flying-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Air Cutter: Special Move"></td>
+				<td class="cen">60</td>
+				<td class="cen">95</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">This move has a 1-stage Critical-Hit Ratio Boost.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/airslash.shtml">Air Slash</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/flying.gif" loading="lazy" alt="Air Slash - Flying-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Air Slash: Special Move"></td>
+				<td class="cen">75</td>
+				<td class="cen">95</td>
+				<td class="cen">16</td>
+				<td class="cen">30</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 30% chance of making the target flinch.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/ancientpower.shtml">Ancient Power</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/rock.gif" loading="lazy" alt="Ancient Power - Rock-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Ancient Power: Special Move"></td>
+				<td class="cen">60</td>
+				<td class="cen">100</td>
+				<td class="cen">8</td>
+				<td class="cen">10</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 10% chance of boosting the user's Attack Defense Sp. Atk Sp. Def and Speed stats by 1 stage.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/beatup.shtml">Beat Up</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dark.gif" loading="lazy" alt="Beat Up - Dark-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Beat Up: Physical Move"></td>
+				<td class="cen">??</td>
+				<td class="cen">100</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The target is attacked as many times as the number of Pok&eacute;mon in the user's party. Pok&eacute;mon that have fainted or have a status condition are not counted. This move's power is calculated based on the Attack stats of the party Pok&eacute;mon.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/bellydrum.shtml">Belly Drum</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Belly Drum - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Belly Drum: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user loses 1/2 of its max HP to boost its Attack stat to its sixth stage. This move fails if the user doesn't have enough remaining HP.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/bite.shtml">Bite</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dark.gif" loading="lazy" alt="Bite - Dark-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Bite: Physical Move"></td>
+				<td class="cen">60</td>
+				<td class="cen">100</td>
+				<td class="cen">20</td>
+				<td class="cen">30</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 30% chance of making the target flinch.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/blastburn.shtml">Blast Burn</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Blast Burn - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Blast Burn: Special Move"></td>
+				<td class="cen">150</td>
+				<td class="cen">90</td>
+				<td class="cen">8</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user gains the Recharging status on the turn after this move is used.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/bodyslam.shtml">Body Slam</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Body Slam - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Body Slam: Physical Move"></td>
+				<td class="cen">85</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">30</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 30% chance of paralyzing the target. If the target has the Minimized status this move's power is doubled and it will be sure to hit.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/breakingswipe.shtml">Breaking Swipe</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dragon.gif" loading="lazy" alt="Breaking Swipe - Dragon-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Breaking Swipe: Physical Move"></td>
+				<td class="cen">60</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Lowers targets' Attack stats by 1 stage.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/brickbreak.shtml">Brick Break</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fighting.gif" loading="lazy" alt="Brick Break - Fighting-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Brick Break: Physical Move"></td>
+				<td class="cen">75</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Removes the Light Screen Reflect and Aurora Veil statuses on the target's side.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/brutalswing.shtml">Brutal Swing</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dark.gif" loading="lazy" alt="Brutal Swing - Dark-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Brutal Swing: Physical Move"></td>
+				<td class="cen">60</td>
+				<td class="cen">100</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6"></td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/bulldoze.shtml">Bulldoze</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/ground.gif" loading="lazy" alt="Bulldoze - Ground-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Bulldoze: Physical Move"></td>
+				<td class="cen">60</td>
+				<td class="cen">100</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Lowers targets' Speed stats by 1 stage. When Grassy Terrain is active this move's power is halved.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/counter.shtml">Counter</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fighting.gif" loading="lazy" alt="Counter - Fighting-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Counter: Physical Move"></td>
+				<td class="cen">??</td>
+				<td class="cen">100</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user retaliates to deal double the damage it took from an opponent's physical move during the turn this move is used.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/crunch.shtml">Crunch</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dark.gif" loading="lazy" alt="Crunch - Dark-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Crunch: Physical Move"></td>
+				<td class="cen">80</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">20</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 20% chance of lowering the target's Defense stat by 1 stage.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/dig.shtml">Dig</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/ground.gif" loading="lazy" alt="Dig - Ground-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Dig: Physical Move"></td>
+				<td class="cen">80</td>
+				<td class="cen">100</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user gains the Underground status on the turn this move is used then attacks on the following turn.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/double-edge.shtml">Double-Edge</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Double-Edge - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Double-Edge: Physical Move"></td>
+				<td class="cen">120</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user takes 1/3 of the damage dealt by this move.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/dragoncheer.shtml">Dragon Cheer</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dragon.gif" loading="lazy" alt="Dragon Cheer - Dragon-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Dragon Cheer: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">16</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Gives allies a Critical-Hit Ratio Boost. Dragon types receive a 2-stage boost. All other types receive a 1-stage boost.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/dragonclaw.shtml">Dragon Claw</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dragon.gif" loading="lazy" alt="Dragon Claw - Dragon-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Dragon Claw: Physical Move"></td>
+				<td class="cen">80</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6"></td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/dragondance.shtml">Dragon Dance</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dragon.gif" loading="lazy" alt="Dragon Dance - Dragon-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Dragon Dance: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Boosts the user's Attack and Speed stats by 1 stage.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/dragonpulse.shtml">Dragon Pulse</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dragon.gif" loading="lazy" alt="Dragon Pulse - Dragon-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Dragon Pulse: Special Move"></td>
+				<td class="cen">85</td>
+				<td class="cen">100</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6"></td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/dragonrush.shtml">Dragon Rush</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dragon.gif" loading="lazy" alt="Dragon Rush - Dragon-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Dragon Rush: Physical Move"></td>
+				<td class="cen">100</td>
+				<td class="cen">75</td>
+				<td class="cen">12</td>
+				<td class="cen">20</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 20% chance of making the target flinch. If the target has the Minimized status this move's power is doubled and it will be sure to hit.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/dragontail.shtml">Dragon Tail</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dragon.gif" loading="lazy" alt="Dragon Tail - Dragon-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Dragon Tail: Physical Move"></td>
+				<td class="cen">60</td>
+				<td class="cen">90</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">If there are other Pok&eacute;mon in the target's party that can switch into battle the target is forced to switch out of battle and is replaced by one of those Pok&eacute;mon at random.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/earthquake.shtml">Earthquake</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/ground.gif" loading="lazy" alt="Earthquake - Ground-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Earthquake: Physical Move"></td>
+				<td class="cen">100</td>
+				<td class="cen">100</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">This move's power is doubled against targets that have the Underground status. When Grassy Terrain is active this move's power is halved.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/endure.shtml">Endure</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Endure - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Endure: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">During the turn this move is used if the user takes damage from a move that would knock it out it will endure the hit with 1 HP. With each consecutive use this move's chance of success becomes 1/3 of what it was before.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/facade.shtml">Facade</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Facade - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Facade: Physical Move"></td>
+				<td class="cen">70</td>
+				<td class="cen">100</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">This move's power is doubled if the user is poisoned badly poisoned burned or paralyzed. Although this move is a physical move the damage it deals is not halved when the user is burned.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/fireblast.shtml">Fire Blast</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Fire Blast - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Fire Blast: Special Move"></td>
+				<td class="cen">110</td>
+				<td class="cen">85</td>
+				<td class="cen">8</td>
+				<td class="cen">10</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 10% chance of burning the target.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/firefang.shtml">Fire Fang</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Fire Fang - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Fire Fang: Physical Move"></td>
+				<td class="cen">65</td>
+				<td class="cen">95</td>
+				<td class="cen">16</td>
+				<td class="cen">10</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 10% chance of burning the target and a 10% chance of making the target flinch.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/firepunch.shtml">Fire Punch</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Fire Punch - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Fire Punch: Physical Move"></td>
+				<td class="cen">75</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">10</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 10% chance of burning the target.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/firespin.shtml">Fire Spin</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Fire Spin - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Fire Spin: Special Move"></td>
+				<td class="cen">35</td>
+				<td class="cen">85</td>
+				<td class="cen">16</td>
+				<td class="cen">100</td></tr>
+				<tr><td class="fooinfo" colspan="6">Gives the target the Bound status.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/flamecharge.shtml">Flame Charge</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Flame Charge - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Flame Charge: Physical Move"></td>
+				<td class="cen">50</td>
+				<td class="cen">100</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Boosts the user's Speed stat by 1 stage.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/flamethrower.shtml">Flamethrower</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Flamethrower - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Flamethrower: Special Move"></td>
+				<td class="cen">90</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">10</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 10% chance of burning the target.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/flareblitz.shtml">Flare Blitz</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Flare Blitz - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Flare Blitz: Physical Move"></td>
+				<td class="cen">120</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">10</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 10% chance of burning the target. Cures the user of being frozen. The user also takes 1/3 of the damage dealt by this move.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/fling.shtml">Fling</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dark.gif" loading="lazy" alt="Fling - Dark-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Fling: Physical Move"></td>
+				<td class="cen">??</td>
+				<td class="cen">100</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">This move's power and effects depend on the user's held item. The held item is lost after this move is used.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/fly.shtml">Fly</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/flying.gif" loading="lazy" alt="Fly - Flying-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Fly: Physical Move"></td>
+				<td class="cen">90</td>
+				<td class="cen">95</td>
+				<td class="cen">16</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user gains the Sky-High status on the turn this move is used then attacks on the following turn.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/focusblast.shtml">Focus Blast</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fighting.gif" loading="lazy" alt="Focus Blast - Fighting-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Focus Blast: Special Move"></td>
+				<td class="cen">120</td>
+				<td class="cen">70</td>
+				<td class="cen">8</td>
+				<td class="cen">10</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 10% chance of lowering the target's Sp. Def stat by 1 stage.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/focuspunch.shtml">Focus Punch</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fighting.gif" loading="lazy" alt="Focus Punch - Fighting-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Focus Punch: Physical Move"></td>
+				<td class="cen">150</td>
+				<td class="cen">100</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">This move fails if the user has already taken damage from a move in the same turn.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/gigaimpact.shtml">Giga Impact</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Giga Impact - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Giga Impact: Physical Move"></td>
+				<td class="cen">150</td>
+				<td class="cen">90</td>
+				<td class="cen">8</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user gains the Recharging status on the turn after this move is used.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/heatcrash.shtml">Heat Crash</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Heat Crash - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Heat Crash: Physical Move"></td>
+				<td class="cen">??</td>
+				<td class="cen">100</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The more the user outweighs the target the greater this move's power (ranging between 40 and 120). If the target has the Minimized status this move's power is doubled and it will be sure to hit.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/heatwave.shtml">Heat Wave</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Heat Wave - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Heat Wave: Special Move"></td>
+				<td class="cen">95</td>
+				<td class="cen">90</td>
+				<td class="cen">12</td>
+				<td class="cen">10</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 10% chance of burning targets.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/helpinghand.shtml">Helping Hand</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Helping Hand - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Helping Hand: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Boosts the power of an ally's move by 50% during the turn this move is used.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/hurricane.shtml">Hurricane</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/flying.gif" loading="lazy" alt="Hurricane - Flying-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Hurricane: Special Move"></td>
+				<td class="cen">110</td>
+				<td class="cen">70</td>
+				<td class="cen">12</td>
+				<td class="cen">30</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 30% chance of confusing the target. This move never misses in rain and can hit a target that has the Sky-High status.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/hyperbeam.shtml">Hyper Beam</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Hyper Beam - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Hyper Beam: Special Move"></td>
+				<td class="cen">150</td>
+				<td class="cen">90</td>
+				<td class="cen">8</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user gains the Recharging status on the turn after this move is used.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/inferno.shtml">Inferno</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Inferno - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Inferno: Special Move"></td>
+				<td class="cen">100</td>
+				<td class="cen">50</td>
+				<td class="cen">8</td>
+				<td class="cen">100</td></tr>
+				<tr><td class="fooinfo" colspan="6">Burns the target.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/irontail.shtml">Iron Tail</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/steel.gif" loading="lazy" alt="Iron Tail - Steel-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Iron Tail: Physical Move"></td>
+				<td class="cen">100</td>
+				<td class="cen">75</td>
+				<td class="cen">16</td>
+				<td class="cen">30</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 30% chance of lowering the target's Defense stat by 1 stage.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/megakick.shtml">Mega Kick</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Mega Kick - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Mega Kick: Physical Move"></td>
+				<td class="cen">120</td>
+				<td class="cen">75</td>
+				<td class="cen">8</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6"></td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/outrage.shtml">Outrage</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dragon.gif" loading="lazy" alt="Outrage - Dragon-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Outrage: Physical Move"></td>
+				<td class="cen">120</td>
+				<td class="cen">100</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user gains the Rampaging status.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/overheat.shtml">Overheat</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Overheat - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Overheat: Special Move"></td>
+				<td class="cen">130</td>
+				<td class="cen">90</td>
+				<td class="cen">8</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Lowers the user's Sp. Atk stat by 2 stages.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/protect.shtml">Protect</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Protect - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Protect: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">8</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user protects itself from incoming moves for the turn. With each consecutive use this move's chance of success becomes 1/3 of what it was before.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/rest.shtml">Rest</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/psychic.gif" loading="lazy" alt="Rest - Psychic-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Rest: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">8</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Fully restores the user's HP and cures any status conditions. The user falls asleep for 2 turns. This move fails if the user's HP is full.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/roar.shtml">Roar</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Roar - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Roar: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">If there are other Pok&eacute;mon in the target's party that can switch into battle the target is forced to switch out of battle and is replaced by one of those Pok&eacute;mon at random.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/rockslide.shtml">Rock Slide</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/rock.gif" loading="lazy" alt="Rock Slide - Rock-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Rock Slide: Physical Move"></td>
+				<td class="cen">75</td>
+				<td class="cen">90</td>
+				<td class="cen">12</td>
+				<td class="cen">30</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 30% chance of making targets flinch.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/rocktomb.shtml">Rock Tomb</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/rock.gif" loading="lazy" alt="Rock Tomb - Rock-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Rock Tomb: Physical Move"></td>
+				<td class="cen">60</td>
+				<td class="cen">95</td>
+				<td class="cen">16</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Lowers the target's Speed stat by 1 stage.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/roost.shtml">Roost</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/flying.gif" loading="lazy" alt="Roost - Flying-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Roost: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">8</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Restores 1/2 of the user's max HP. If the user is a Flying type it will lose the Flying type for the turn.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/round.shtml">Round</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Round - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Round: Special Move"></td>
+				<td class="cen">60</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">If multiple Pok&eacute;mon use this move in the same turn the second user onward will act immediately after the first and the power of the second Round onward will be doubled.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/sandstorm.shtml">Sandstorm</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/rock.gif" loading="lazy" alt="Sandstorm - Rock-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Sandstorm: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">8</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Summons a sandstorm for 5 turns.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/scaleshot.shtml">Scale Shot</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/dragon.gif" loading="lazy" alt="Scale Shot - Dragon-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Scale Shot: Physical Move"></td>
+				<td class="cen">25</td>
+				<td class="cen">90</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user attacks 2 to 5 times in a row. This move lowers the user's Defense stat by 1 stage and boosts its Speed stat by 1 stage.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/scaryface.shtml">Scary Face</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Scary Face - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Scary Face: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">100</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Lowers the target's Speed stat by 2 stages.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/scorchingsands.shtml">Scorching Sands</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/ground.gif" loading="lazy" alt="Scorching Sands - Ground-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Scorching Sands: Special Move"></td>
+				<td class="cen">70</td>
+				<td class="cen">100</td>
+				<td class="cen">12</td>
+				<td class="cen">30</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 30% chance of burning the target. Cures the user and target of being frozen.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/shadowclaw.shtml">Shadow Claw</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/ghost.gif" loading="lazy" alt="Shadow Claw - Ghost-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Shadow Claw: Physical Move"></td>
+				<td class="cen">70</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">This move has a 1-stage Critical-Hit Ratio Boost.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/sleeptalk.shtml">Sleep Talk</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Sleep Talk - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Sleep Talk: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Can be used only if the user is asleep. The user uses one of the other moves it knows at random.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/snore.shtml">Snore</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Snore - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Snore: Special Move"></td>
+				<td class="cen">50</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">30</td></tr>
+				<tr><td class="fooinfo" colspan="6">Can be used only if the user is asleep. Has a 30% chance of making the target flinch.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/solarbeam.shtml">Solar Beam</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/grass.gif" loading="lazy" alt="Solar Beam - Grass-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Solar Beam: Special Move"></td>
+				<td class="cen">120</td>
+				<td class="cen">100</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user gains the Charging status on the turn this move is used then attacks on the following turn. In harsh sunlight the user does not gain the Charging status and can attack immediately. This move's power is halved in any other weather condition.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/steelwing.shtml">Steel Wing</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/steel.gif" loading="lazy" alt="Steel Wing - Steel-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Steel Wing: Physical Move"></td>
+				<td class="cen">70</td>
+				<td class="cen">90</td>
+				<td class="cen">20</td>
+				<td class="cen">10</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 10% chance of boosting the user's Defense stat by 1 stage.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/substitute.shtml">Substitute</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Substitute - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Substitute: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">The user loses 1/4 of its max HP to create a substitute. The substitute will be hit by moves instead of the user and it will vanish when it takes damage equal to 1/4 of the user's max HP.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/sunnyday.shtml">Sunny Day</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Sunny Day - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Sunny Day: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">8</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Summons harsh sunlight for 5 turns.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/swordsdance.shtml">Swords Dance</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Swords Dance - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Swords Dance: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">101</td>
+				<td class="cen">20</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Boosts the user's Attack stat by 2 stages.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/temperflare.shtml">Temper Flare</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Temper Flare - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Temper Flare: Physical Move"></td>
+				<td class="cen">75</td>
+				<td class="cen">100</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">This move's power is doubled if the user couldn't act or its move missed or failed on the previous turn.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/thunderpunch.shtml">Thunder Punch</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/electric.gif" loading="lazy" alt="Thunder Punch - Electric-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/physical.png" loading="lazy" alt="Thunder Punch: Physical Move"></td>
+				<td class="cen">75</td>
+				<td class="cen">100</td>
+				<td class="cen">16</td>
+				<td class="cen">10</td></tr>
+				<tr><td class="fooinfo" colspan="6">Has a 10% chance of paralyzing the target.</td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/weatherball.shtml">Weather Ball</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/normal.gif" loading="lazy" alt="Weather Ball - Normal-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/special.png" loading="lazy" alt="Weather Ball: Special Move"></td>
+				<td class="cen">50</td>
+				<td class="cen">100</td>
+				<td class="cen">12</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">When a weather condition is present this move's power is doubled and its type changes. Harsh sunlight<br /> Fire type. Rain<br /> Water type. Snow<br /> Ice type. Sandstorm<br /> Rock type.<br /></td></tr><tr>
+				<td rowspan="2" class="fooinfo"><a href="/attackdex-champions/will-o-wisp.shtml">Will-O-Wisp</a></td>
+				<td class="cen"><img src="/pokedex-bw/type/fire.gif" loading="lazy" alt="Will-O-Wisp - Fire-type"></td>
+				<td class="cen"><img src="/pokedex-bw/type/other.png" loading="lazy" alt="Will-O-Wisp: Other Move"></td>
+				<td class="cen">--</td>
+				<td class="cen">85</td>
+				<td class="cen">16</td>
+				<td class="cen">--</td></tr>
+				<tr><td class="fooinfo" colspan="6">Burns the target.</td></tr></table><br /><br /><br /><a name="stats"></a><table class="dextable"><tr>
+<td colspan="8" class="fooevo"><h2>Stats</h2></td></tr><tr>
+<td colspan="2" width="14%">&nbsp;</td>
+<td align="center" class="fooevo">HP</td>
+<td align="center" class="fooevo">Attack</td>
+<td align="center" class="fooevo">Defense</td>
+<td align="center" class="fooevo">Sp. Attack</td>
+<td align="center" class="fooevo">Sp. Defense</td>
+<td align="center" class="fooevo">Speed</td></tr>
+<tr><td colspan="2" width="14%" class="fooinfo">Base Stats - Total: 634</td>
+<td align="center" class="fooinfo">78</td>
+<td align="center" class="fooinfo">104</td>
+<td align="center" class="fooinfo">78</td>
+<td align="center" class="fooinfo">159</td>
+<td align="center" class="fooinfo">115</td>
+<td align="center" class="fooinfo">100</td></tr>
+<tr><td width="14%" class="foohin">Max Stats<br /><i>Hindering Nature</i></td>
+<td class="foohin">Standard</td>
+<td align="center" class="foohin">153 - 185</td>
+<td align="center" class="foohin">111 - 140</td>
+<td align="center" class="foohin">88 - 117</td>
+<td align="center" class="foohin">161 - 189</td>
+<td align="center" class="foohin">121 - 150</td>
+<td align="center" class="foohin">108 - 136</td></tr>
+
+
+<tr><td width="14%" class="fooinfo">Max Stats<br /><i>Neutral Nature</i></td>
+<td class="fooinfo">Standard</td>
+<td align="center" class="fooinfo">153 - 185</td>
+<td align="center" class="fooinfo">124 - 156</td>
+<td align="center" class="fooinfo">98 - 130</td>
+<td align="center" class="fooinfo">179 - 211</td>
+<td align="center" class="fooinfo">135 - 167</td>
+<td align="center" class="fooinfo">120 - 152</td></tr>
+
+
+<tr><td width="14%" class="fooben">Max Stats<br /><i>Beneficial Nature</i></td>
+<td class="fooben">Standard</td>
+<td align="center" class="fooben">153 - 185</td>
+<td align="center" class="fooben">136 - 171</td>
+<td align="center" class="fooben">107 - 143</td>
+<td align="center" class="fooben">196 - 232</td>
+<td align="center" class="fooben">148 - 183</td>
+<td align="center" class="fooben">132 - 167</td></tr>
+
+
+</table><div align="center">
+<div class="radar-graph" style="background-image:url('/pokedex-champions/hexagon200.png');">
+	<div class="polygon" style="clip-path: polygon(250px 170.05px,342.32px 196.7px,319.24px 289.98px,250px 352.5px,147.92px 308.94px,108.86px 168.51px)"></div>
+	<div class="label" style="top:160.05px;left:250px;">78</div><div class="label" style="top:191.7px;left:350.98px;">104</div><div class="label" style="top:294.98px;left:327.9px;">78</div><div class="label" style="top:362.5px;left:250px;">100</div><div class="label" style="top:313.94px;left:139.26px;">115</div><div class="label" style="top:163.51px;left:100.2px;">159</div>
+</div>
+
+</div>
+
+<p><hr width="100%" color="507C36" border="1"></hr></p><a name="mega"></a><table class="dextable">
+		<tr><td class="fooevo" colspan="6"><h3>Mega Charizard X</h3></td></tr><tr>
+			<td class="fooevo" width="120">Picture</td>
+			
+		</tr>
+		<tr>
+			<td class="fooinfo" rowspan="3" align="center"><table><tr><td class="pkmn"><img src="/legendsz-a/pokemon/006-mx.png" /></td><td class="pkmn"><img src="/Shiny/ZA/006-mx.png" /></td></tr></table></td></tr></table>
+<table class="dextable">
+		<tr>
+		<td class="fooevo">Name</td>
+			<td class="fooevo">Other Names</td>
+			<td class="fooevo">No.</td>
+			<td class="fooevo">Type</td>
+		</tr>
+		<tr>
+			
+			<td class="fooinfo">Mega  Charizard</td>
+			<td class="fooinfo"><table width="120" cellspacing="0" cellpadding="0">
+			<tr> <td><b>Japan</b>: </td><td>Mega Rizardon<br />&#12513;&#12460;&#12522;&#12470;&#12540;&#12489;&#12531;</td></tr>
+			<tr> <td><b>French</b>: </td><td>Mega Dracaufeu</td></tr>
+			<tr> <td><b>German</b>: </td><td>Mega -Glurak</td></tr>
+			<tr> <td><b>Korean</b>: </td><td>&#47700;&#44032;&#47532;&#51088;&#47805;</td></tr>
+			</table></td>
+			<td class="fooinfo"><table width="120" cellspacing="0" cellpadding="0"><tr> <td><b>National</b>: </td><td>#006</td></tr>
+
+			</table></td>
+
+			<td class="cen"><a href="/pokedex-sm/fire.shtml"><img src="/pokedex-bw/type/fire.gif" border="0" /></a> <a href="/pokedex-sm/dragon.shtml"><img src="/pokedex-bw/type/dragon.gif" border="0" /></a></td>
+
+		</tr>
+		<tr>
+			<td class="foo">Classification</td>
+			<td class="foo">Height</td>
+			<td class="foo">Weight</td>
+			<td class="foo">Capture Rate</td>
+		</tr>
+		<tr>
+			<td class="fooinfo">Flame Pok&eacute;mon</td>
+			<td class="fooinfo">5'07"<br />
+			1.7m</td>
+			<td class="fooinfo">243.6lbs<br />
+			110.5kg</td>
+			<td class="fooinfo"></td>
+			
+		</tr></table>
+		<table class="dextable">		<tr>
+			<td align="left" colspan="6" class="fooleft"><b>Abilities</b>: <a href="/abilitydex/toughclaws.shtml"><b>Tough Claws</b></a> </td>
+		</tr>
+		<tr>
+			<td align="left" colspan="5" class="fooinfo">
+<a href="/abilitydex/toughclaws.shtml"><b>Tough Claws</b></a>: Increases the power of moves that make physical contact by 30% </td>
+		</tr></table><table class="dextable">
+	<tr>
+		<td colspan="18" class="foo">
+		Damage Taken
+		</td>
+	</tr>
+<tr>	
+	<td class="footype">
+		<a href="/attackdex-champions/normal.shtml"><img src="/pokedex-sv/type/icon/normal.png" loading="lazy" alt="Attacking Move Type: Normal-type" title="Attacking Move Type: Normal-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/fire.shtml"><img src="/pokedex-sv/type/icon/fire.png" loading="lazy" alt="Attacking Move Type: Fire-type" title="Attacking Move Type: Fire-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/water.shtml"><img src="/pokedex-sv/type/icon/water.png" loading="lazy" alt="Attacking Move Type: Water-type" title="Attacking Move Type: Water-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/electric.shtml"><img src="/pokedex-sv/type/icon/electric.png" loading="lazy" alt="Attacking Move Type: Electric-type" title="Attacking Move Type: Electric-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/grass.shtml"><img src="/pokedex-sv/type/icon/grass.png" loading="lazy" alt="Attacking Move Type: Grass-type" title="Attacking Move Type: Grass-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/ice.shtml"><img src="/pokedex-sv/type/icon/ice.png" loading="lazy" alt="Attacking Move Type: Ice-type" title="Attacking Move Type: Ice-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/fighting.shtml"><img src="/pokedex-sv/type/icon/fighting.png" loading="lazy" alt="Attacking Move Type: Fighting-type" title="Attacking Move Type: Fighting-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/poison.shtml"><img src="/pokedex-sv/type/icon/poison.png" loading="lazy" alt="Attacking Move Type: Poison-type" title="Attacking Move Type: Poison-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/ground.shtml"><img src="/pokedex-sv/type/icon/ground.png" loading="lazy" alt="Attacking Move Type: Ground-type" title="Attacking Move Type: Ground-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/flying.shtml"><img src="/pokedex-sv/type/icon/flying.png" loading="lazy" alt="Attacking Move Type: Flying-type" title="Attacking Move Type: Flying-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/psychict.shtml"><img src="/pokedex-sv/type/icon/psychic.png" loading="lazy" alt="Attacking Move Type: Psychic-type" title="Attacking Move Type: Psychic-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/bug.shtml"><img src="/pokedex-sv/type/icon/bug.png" loading="lazy" alt="Attacking Move Type: Bug-type" title="Attacking Move Type: Bug-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/rock.shtml"><img src="/pokedex-sv/type/icon/rock.png" loading="lazy" alt="Attacking Move Type: Rock-type" title="Attacking Move Type: Rock-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/ghost.shtml"><img src="/pokedex-sv/type/icon/ghost.png" loading="lazy" alt="Attacking Move Type: Ghost-type" title="Attacking Move Type: Ghost-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/dragon.shtml"><img src="/pokedex-sv/type/icon/dragon.png" loading="lazy" alt="Attacking Move Type: Dragon-type" title="Attacking Move Type: Dragon-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/dark.shtml"><img src="/pokedex-sv/type/icon/dark.png" loading="lazy" alt="Attacking Move Type: Dark-type" title="Attacking Move Type: Dark-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/steel.shtml"><img src="/pokedex-sv/type/icon/steel.png" loading="lazy" alt="Attacking Move Type: Steel-type" title="Attacking Move Type: Steel-type" height="25" /></a>
+		</td>		<td class="footype">
+		<a href="/attackdex-champions/fairy.shtml"><img src="/pokedex-sv/type/icon/fairy.png" loading="lazy" alt="Attacking Move Type: Fairy-type" title="Attacking Move Type: Fairy-type" height="25" /></a>
+		</td></tr><tr>
+			<td class="footype">*1</td>
+			<td class="footype">*0.25</td>
+			<td class="footype">*1</td>
+			<td class="footype">*0.5</td>
+			<td class="footype">*0.25</td>
+			<td class="footype">*1</td>
+			<td class="footype">*1</td>
+			<td class="footype">*1</td>
+			<td class="footype">*2</td>
+			<td class="footype">*1</td>
+			<td class="footype">*1</td>
+			<td class="footype">*0.5</td>
+			<td class="footype">*2</td>
+			<td class="footype">*1</td>
+			<td class="footype">*2</td>
+			<td class="footype">*1</td>
+			<td class="footype">*0.5</td>
+			<td class="footype">*1</td>
+		</tr>
+		</table><br /><br /><table class="dextable"><tr>
+<td colspan="8" class="fooevo"><h2>Stats - </h2></td></tr><tr>
+<td colspan="2" width="14%">&nbsp;</td>
+<td align="center" class="fooevo">HP</td>
+<td align="center" class="fooevo">Attack</td>
+<td align="center" class="fooevo">Defense</td>
+<td align="center" class="fooevo">Sp. Attack</td>
+<td align="center" class="fooevo">Sp. Defense</td>
+<td align="center" class="fooevo">Speed</td></tr>
+<tr><td colspan="2" width="14%" class="fooinfo">Base Stats - Total: 634</td>
+<td align="center" class="fooinfo">78</td>
+<td align="center" class="fooinfo">130</td>
+<td align="center" class="fooinfo">111</td>
+<td align="center" class="fooinfo">130</td>
+<td align="center" class="fooinfo">85</td>
+<td align="center" class="fooinfo">100</td></tr>
+<tr><td width="14%" class="foohin">Max Stats<br /><i>Hindering Nature</i></td>
+<td class="foohin">Standard</td>
+<td align="center" class="foohin">153 - 185</td>
+<td align="center" class="foohin">135 - 163</td>
+<td align="center" class="foohin">117 - 146</td>
+<td align="center" class="foohin">135 - 163</td>
+<td align="center" class="foohin">94 - 123</td>
+<td align="center" class="foohin">108 - 136</td></tr>
+
+
+
+<tr><td width="14%" class="fooinfo">Max Stats<br /><i>Neutral Nature</i></td>
+<td class="fooinfo">Standard</td>
+<td align="center" class="fooinfo">153 - 185</td>
+<td align="center" class="fooinfo">150 - 182</td>
+<td align="center" class="fooinfo">131 - 163</td>
+<td align="center" class="fooinfo">150 - 182</td>
+<td align="center" class="fooinfo">105 - 137</td>
+<td align="center" class="fooinfo">120 - 152</td></tr>
+
+
+
+<tr><td width="14%" class="fooben">Max Stats<br /><i>Beneficial Nature</i></td>
+<td class="fooben">Standard</td>
+<td align="center" class="fooben">153 - 185</td>
+<td align="center" class="fooben">165 - 200</td>
+<td align="center" class="fooben">144 - 179</td>
+<td align="center" class="fooben">165 - 200</td>
+<td align="center" class="fooben">115 - 150</td>
+<td align="center" class="fooben">132 - 167</td></tr>
+
+
+
+</table><div align="center"><div class="radar-graph" style="background-image:url('/pokedex-champions/hexagon200.png');">
+	<div class="polygon" style="clip-path: polygon(250px 170.05px,365.4px 183.37px,348.53px 306.89px,250px 352.5px,174.55px 293.56px,134.6px 183.37px)"></div>
+	<div class="label" style="top:160.05px;left:250px;">78</div><div class="label" style="top:178.37px;left:374.06px;">130</div><div class="label" style="top:311.89px;left:357.19px;">111</div><div class="label" style="top:362.5px;left:250px;">100</div><div class="label" style="top:298.56px;left:165.89px;">85</div><div class="label" style="top:178.37px;left:125.94px;">130</div>
+</div>
+</div><p><hr width="100%" color="507C36" border="1"></hr></p><a name="mega"></a><table class="dextable">
+		<tr><td class="fooevo" colspan="6"><h3>Mega Charizard Y</h3></td></tr><tr>
+			<td class="fooevo" width="120">Picture</td>
+			
+		</tr>
+		<tr>
+			<td class="fooinfo" rowspan="3" align="center"><table><tr><td class="pkmn"><img src="/legendsz-a/pokemon/006-my.png" /></td><td class="pkmn"><img src="/Shiny/ZA/006-my.png" /></td></tr></table></td></tr></table>
+<table class="dextable">
+		<tr>
+		<td class="fooevo">Name</td>
+			<td class="fooevo">Other Names</td>
+			<td class="fooevo">No.</td>
+			<td class="fooevo">Type</td>
+		</tr>
+		<tr>
+			
+			<td class="fooinfo">Mega  Charizard</td>
+			<td class="fooinfo"><table width="120" cellspacing="0" cellpadding="0">
+			<tr> <td><b>Japan</b>: </td><td>Mega Rizardon<br />&#12513;&#12460;&#12522;&#12470;&#12540;&#12489;&#12531;</td></tr>
+			<tr> <td><b>French</b>: </td><td>Mega Dracaufeu</td></tr>
+			<tr> <td><b>German</b>: </td><td>Mega -Glurak</td></tr>
+			<tr> <td><b>Korean</b>: </td><td>&#47700;&#44032;&#47532;&#51088;&#47805;</td></tr>
+			</table></td>
+			<td class="fooinfo"><table width="120" cellspacing="0" cellpadding="0"><tr> <td><b>National</b>: </td><td>#006</td></tr>
+
+			</table></td>
+
+			<td class="cen"><a href="/pokedex-sm/.shtml"><img src="/pokedex-bw/type/.gif" border="0" /></a></td>
+
+		</tr>
+		<tr>
+			<td class="foo">Classification</td>
+			<td class="foo">Height</td>
+			<td class="foo">Weight</td>
+			<td class="foo">Capture Rate</td>
+		</tr>
+		<tr>
+			<td class="fooinfo">Flame Pok&eacute;mon</td>
+			<td class="fooinfo">5'07"<br />
+			1.7m</td>
+			<td class="fooinfo">221.6lbs<br />
+			100.5kg</td>
+			<td class="fooinfo"></td>
+			
+		</tr></table>
+		<table class="dextable">		<tr>
+			<td align="left" colspan="6" class="fooleft"><b>Abilities</b>: <a href="/abilitydex/.shtml"><b></b></a> </td>
+		</tr>
+		<tr>
+			<td align="left" colspan="5" class="fooinfo">
+<a href="/abilitydex/.shtml"><b></b></a>:  </td>
+		</tr></table><table class="dextable">
+	<tr>
+		<td colspan="18" class="foo">
+		Damage Taken
+		</td>
+	</tr>
+<tr>	
+	<td class="footype">
+		<a href="/attackdex-champions/normal.shtml"><img src="/pokedex-sv/type/icon/normal.png" loading="lazy" alt="Attacking Move Type: Normal-type" title="Attacking Move Type: Normal-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/fire.shtml"><img src="/pokedex-sv/type/icon/fire.png" loading="lazy" alt="Attacking Move Type: Fire-type" title="Attacking Move Type: Fire-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/water.shtml"><img src="/pokedex-sv/type/icon/water.png" loading="lazy" alt="Attacking Move Type: Water-type" title="Attacking Move Type: Water-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/electric.shtml"><img src="/pokedex-sv/type/icon/electric.png" loading="lazy" alt="Attacking Move Type: Electric-type" title="Attacking Move Type: Electric-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/grass.shtml"><img src="/pokedex-sv/type/icon/grass.png" loading="lazy" alt="Attacking Move Type: Grass-type" title="Attacking Move Type: Grass-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/ice.shtml"><img src="/pokedex-sv/type/icon/ice.png" loading="lazy" alt="Attacking Move Type: Ice-type" title="Attacking Move Type: Ice-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/fighting.shtml"><img src="/pokedex-sv/type/icon/fighting.png" loading="lazy" alt="Attacking Move Type: Fighting-type" title="Attacking Move Type: Fighting-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/poison.shtml"><img src="/pokedex-sv/type/icon/poison.png" loading="lazy" alt="Attacking Move Type: Poison-type" title="Attacking Move Type: Poison-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/ground.shtml"><img src="/pokedex-sv/type/icon/ground.png" loading="lazy" alt="Attacking Move Type: Ground-type" title="Attacking Move Type: Ground-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/flying.shtml"><img src="/pokedex-sv/type/icon/flying.png" loading="lazy" alt="Attacking Move Type: Flying-type" title="Attacking Move Type: Flying-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/psychict.shtml"><img src="/pokedex-sv/type/icon/psychic.png" loading="lazy" alt="Attacking Move Type: Psychic-type" title="Attacking Move Type: Psychic-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/bug.shtml"><img src="/pokedex-sv/type/icon/bug.png" loading="lazy" alt="Attacking Move Type: Bug-type" title="Attacking Move Type: Bug-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/rock.shtml"><img src="/pokedex-sv/type/icon/rock.png" loading="lazy" alt="Attacking Move Type: Rock-type" title="Attacking Move Type: Rock-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/ghost.shtml"><img src="/pokedex-sv/type/icon/ghost.png" loading="lazy" alt="Attacking Move Type: Ghost-type" title="Attacking Move Type: Ghost-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/dragon.shtml"><img src="/pokedex-sv/type/icon/dragon.png" loading="lazy" alt="Attacking Move Type: Dragon-type" title="Attacking Move Type: Dragon-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/dark.shtml"><img src="/pokedex-sv/type/icon/dark.png" loading="lazy" alt="Attacking Move Type: Dark-type" title="Attacking Move Type: Dark-type" height="25" /></a>
+		</td>
+		<td class="footype">
+		<a href="/attackdex-champions/steel.shtml"><img src="/pokedex-sv/type/icon/steel.png" loading="lazy" alt="Attacking Move Type: Steel-type" title="Attacking Move Type: Steel-type" height="25" /></a>
+		</td>		<td class="footype">
+		<a href="/attackdex-champions/fairy.shtml"><img src="/pokedex-sv/type/icon/fairy.png" loading="lazy" alt="Attacking Move Type: Fairy-type" title="Attacking Move Type: Fairy-type" height="25" /></a>
+		</td></tr><tr>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+			<td class="footype">*</td>
+		</tr>
+		</table><br /><br /><table class="dextable"><tr>
+<td colspan="8" class="fooevo"><h2>Stats - </h2></td></tr><tr>
+<td colspan="2" width="14%">&nbsp;</td>
+<td align="center" class="fooevo">HP</td>
+<td align="center" class="fooevo">Attack</td>
+<td align="center" class="fooevo">Defense</td>
+<td align="center" class="fooevo">Sp. Attack</td>
+<td align="center" class="fooevo">Sp. Defense</td>
+<td align="center" class="fooevo">Speed</td></tr>
+<tr><td colspan="2" width="14%" class="fooinfo">Base Stats - Total: 0</td>
+<td align="center" class="fooinfo"></td>
+<td align="center" class="fooinfo"></td>
+<td align="center" class="fooinfo"></td>
+<td align="center" class="fooinfo"></td>
+<td align="center" class="fooinfo"></td>
+<td align="center" class="fooinfo"></td></tr>
+<tr><td width="14%" class="foohin">Max Stats<br /><i>Hindering Nature</i></td>
+<td class="foohin">Standard</td>
+<td align="center" class="foohin">75 - 107</td>
+<td align="center" class="foohin">18 - 46</td>
+<td align="center" class="foohin">18 - 46</td>
+<td align="center" class="foohin">18 - 46</td>
+<td align="center" class="foohin">18 - 46</td>
+<td align="center" class="foohin">18 - 46</td></tr>
+
+
+
+<tr><td width="14%" class="fooinfo">Max Stats<br /><i>Neutral Nature</i></td>
+<td class="fooinfo">Standard</td>
+<td align="center" class="fooinfo">75 - 107</td>
+<td align="center" class="fooinfo">20 - 52</td>
+<td align="center" class="fooinfo">20 - 52</td>
+<td align="center" class="fooinfo">20 - 52</td>
+<td align="center" class="fooinfo">20 - 52</td>
+<td align="center" class="fooinfo">20 - 52</td></tr>
+
+
+
+<tr><td width="14%" class="fooben">Max Stats<br /><i>Beneficial Nature</i></td>
+<td class="fooben">Standard</td>
+<td align="center" class="fooben">75 - 107</td>
+<td align="center" class="fooben">22 - 57</td>
+<td align="center" class="fooben">22 - 57</td>
+<td align="center" class="fooben">22 - 57</td>
+<td align="center" class="fooben">22 - 57</td>
+<td align="center" class="fooben">22 - 57</td></tr>
+
+
+
+</table><div align="center"><div class="radar-graph" style="background-image:url('/pokedex-champions/hexagon200.png');">
+	<div class="polygon" style="clip-path: polygon(250px 250px,250px 250px,250px 250px,250px 250px,250px 250px,250px 250px)"></div>
+	<div class="label" style="top:240px;left:250px;"></div><div class="label" style="top:245px;left:258.66px;"></div><div class="label" style="top:255px;left:258.66px;"></div><div class="label" style="top:260px;left:250px;"></div><div class="label" style="top:255px;left:241.34px;"></div><div class="label" style="top:245px;left:241.34px;"></div>
+</div>
+</div><p>
+<table width="100%" border="0" cellpadding="4">
+	<tr>
+		<td width="50%" align="left">
+		
+<table border="0">
+	<tr>
+		<td width="left">
+		<--- 
+		</td>
+		<td>
+		<a href="/pokedex-champions/venusaur/"><img src="/pokedex-champions/icon/003.png" alt="Venusaur"  border="0"></a>
+		</td>
+		<td align="center">
+		<a href="/pokedex-champions/venusaur/">#003<br />Venusaur
+		</td>
+	</tr>
+</table>
+
+		</td>
+		<td width="50%" align="right">
+		<table border="0">
+	<tr>
+		<td align="center">
+		<a href="/pokedex-champions/blastoise/">#009<br />Blastoise
+		</td>
+		<td>
+		<a href="/pokedex-champions/blastoise/"><img src="/pokedex-champions/icon/009.png" alt="Blastoise" border="0"></a>
+		</td>
+		<td width="right">
+		---> 
+		</td>
+	</tr>
+</table>
+
+		</td>
+	</tr>
+</table>
+</div>
+</td>
+</main></div><!-- END id="content" -->
+
+
+<aside id="rbar">
+<div class="navheader">Picture</div><br /><table width="140" class="art" cellspacing="0" cellpadding="0"><tr><td align="center"><a href="/pokemon/charizard/"><img src="/art/th/6.png" border="0" alt="Charizard Art" /></a></td></tr></table>
+<table width="140" class="tooltab"><tr><td class="tooltabhead" width="50%">Name</td><td class="tooltabhead">Jp. Name</td></tr><tr><td class="tooltabcon">Charizard</td><td class="tooltabcon">Lizardon<br />&#12522;&#12470;&#12540;&#12489;&#12531;</td></tr></table>
+<table width="140" class="tooltab"><tr><td class="tooltabhead" width="50%">Gender</td><td class="tooltabhead">Type</td></tr><tr><td class="tooltabcon"><table width="60" cellspacing="0" cellpadding="0"><tr> <td>&nbsp;<font color="#499FFF" size="1">&#9794;</font>:</td><td>87.5%</td></tr><tr><td>&nbsp;<font color="#F6807A" size="1">&#9792;</font>:</td><td>12.5%</td></tr></table></td><td class="tooltabcon"><a href="/pokedex-sm/fire.shtml"><img src="/pokedex-bw/type/fire.gif" border="0" alt="Fire-type" /></a> <a href="/pokedex-sm/flying.shtml"><img src="/pokedex-bw/type/flying.gif" border="0" alt="Flying-type" /></a></td></tr></table>
+<table width="140" class="tooltab"><tr><td class="tooltabhead" width="50%">Classification</td></tr><tr><td class="tooltabcon">Flame Pokémon</td></tr></table>
+<table width="140" class="tooltab"><tr><td class="tooltabhead" width="50%">Height</td><td class="tooltabhead">Weight</td></tr><tr><td class="tooltabcon">5’07”<br />
+			1.7m</td><td class="tooltabcon">199.5lbs<br />
+			90.5kg</td></tr></table>
+
+			
+			<br />
+<div class="alterdex"><br /><a href="/pokedex-sv/charizard/"><b>Pokédex</b></a><br /></div><div class="alterdex"><br /><a href="/events/dex/006.shtml"><b>Events</b></a><br /></div>
+<div class="alterdex"><br /><a href="/anime/dex/006.shtml"><b>Anime Appearances</b></a><br /></div>
+<div class="alterdex"><br /><a href="/card/dex/006.shtml"><b>Cards</b></a><br /></div>
+<div class="alterdex"><br /><a href="/movies/dex/006.shtml"><b>Cinematic Pok&eacute;dex</b></a><br /></div>
+<div class="alterdex"><br /><a href="/manga/dex/006.shtml"><b>Manga Appearances</b></a><br /></div>
+<div class="alterdex"><br /><a href="/pokemongo/pokemon/006.shtml"><b>Pokémon GO</b></a><br /></div>
+<table width="140" class="tooltab">
+<tr><td class="tooltabhead" width="34">Prev.</td><td  width="99%">&nbsp;</td><td class="tooltabhead" width="32">Next</td></tr>
+<tr><td class="tooltabcon" width="34"><a href="/pokedex-sv/charmeleon"><img src="/pokedex-sv/icon/005.png" border="0" /></a></td><td  width="99%">&nbsp;</td><td class="tooltabcon" width="32"><a href="/pokedex-sv/squirtle"><img src="/pokedex-sv/icon/007.png" border="0" /></a></td></tr></table>
+<table width="140" class="art" cellspacing="0" cellpadding="0"><tr><td align="center"><img src="/art/th/6-mx.png" alt="Mega Charizard X Artwork" /></td></tr></table>
+<table width="140" class="tooltab"><tr><td class="tooltabhead" width="50%">Name</td><td class="tooltabhead">Jp. Name</td></tr><tr><td class="tooltabcon">Mega Charizard X</td><td class="tooltabcon">MegaRizardonX<br />&#12513;&#12460;&#12522;&#12470;&#12540;&#12489;&#12531;X</td></tr></table>
+<table width="140" class="tooltab"><tr><td class="tooltabhead" width="50%">Gender</td><td class="tooltabhead">Type</td></tr><tr><td class="tooltabcon"><table width="60" cellspacing="0" cellpadding="0"><tr> <td>&nbsp;<font color="#499FFF" size="1">&#9794;</font>:</td><td>87.5%</td></tr><tr><td>&nbsp;<font color="#F6807A" size="1">&#9792;</font>:</td><td>12.5%</td></tr></table></td><td class="tooltabcon"><a href="/pokedex-sm/fire.shtml"><img src="/pokedex-bw/type/fire.gif" border="0" alt="Fire-type" /></a> <a href="/pokedex-sm/dragon.shtml"><img src="/pokedex-bw/type/dragon.gif" border="0" alt="Dragon-type" /></a></td></tr></table>
+<table width="140" class="tooltab"><tr><td class="tooltabhead" width="50%">Classification</td></tr><tr><td class="tooltabcon">Flame Pokémon</td></tr></table>
+<table width="140" class="tooltab"><tr><td class="tooltabhead" width="50%">Height</td><td class="tooltabhead">Weight</td></tr><tr><td class="tooltabcon">5’07”<br />
+			1.7m</td><td class="tooltabcon">243.6lbs<br />
+			110.5kg</td></tr></table><table width="140" class="art" cellspacing="0" cellpadding="0"><tr><td align="center"><img src="/art/th/6-my.png" alt="Mega Charizard Y Artwork" /></td></tr></table>
+<table width="140" class="tooltab"><tr><td class="tooltabhead" width="50%">Name</td><td class="tooltabhead">Jp. Name</td></tr><tr><td class="tooltabcon">Mega Charizard Y</td><td class="tooltabcon">MegaRizardonY<br />&#12513;&#12460;&#12522;&#12470;&#12540;&#12489;&#12531;Y</td></tr></table>
+<table width="140" class="tooltab"><tr><td class="tooltabhead" width="50%">Gender</td><td class="tooltabhead">Type</td></tr><tr><td class="tooltabcon"><table width="60" cellspacing="0" cellpadding="0"><tr> <td>&nbsp;<font color="#499FFF" size="1">&#9794;</font>:</td><td>87.5%</td></tr><tr><td>&nbsp;<font color="#F6807A" size="1">&#9792;</font>:</td><td>12.5%</td></tr></table></td><td class="tooltabcon"><a href="/pokedex-sm/fire.shtml"><img src="/pokedex-bw/type/fire.gif" border="0" alt="Fire-type" /></a> <a href="/pokedex-sm/flying.shtml"><img src="/pokedex-bw/type/flying.gif" border="0" alt="Flying-type" /></a></td></tr></table>
+<table width="140" class="tooltab"><tr><td class="tooltabhead" width="50%">Classification</td></tr><tr><td class="tooltabcon">Flame Pokémon</td></tr></table>
+<table width="140" class="tooltab"><tr><td class="tooltabhead" width="50%">Height</td><td class="tooltabhead">Weight</td></tr><tr><td class="tooltabcon">5’07”<br />
+			1.7m</td><td class="tooltabcon">221.6lbs<br />
+			100.5kg</td></tr></table>
+
+			
+</div>
+</aside>
+
+</div><!-- END id="wrapper" -->
+
+
+
+<footer id="footer">
+	<div class="copyright">
+		<a href="#top" alt="Top of Page" title="Top of Page" class="totop"></a>
+
+		All Content is &copy; Copyright of Serebii.net 1999-2026. |
+		<a href="/privacy.shtml">Privacy Policy</a> |
+		<a class="nn-cmp-show" href="#">Manage Cookie Settings</a><br/>
+		Pokémon and All Respective Names are Trademark &amp; &copy; of Nintendo 1996-2026<br /><br />
+<a href="https://www.patreon.com/serebiinet" target="blank" rel="nofollow"></u>Support us on Patreon</u></a>
+	</div>
+
+	<div style="height:102px">
+		<div id="nn_lb2"></div><div id="nn_mobile_lb2"></div>
+<div id="celtra-reveal-wrapper" style="position:fixed; height: auto; width: 100%">
+<div id="nn_1by1"></div>
+</div>
+	</div>
+<script data-cfasync="false" async src="//cdn.intergient.com/1025662/76683/ramp.js"></script>
+</footer>
+
+
+</body>
+</html>

--- a/tests/test_champions_pokemon_list.py
+++ b/tests/test_champions_pokemon_list.py
@@ -1,6 +1,5 @@
 """Tests for fetcher/champions_pokemon_list.py — static Champions Pokemon list."""
 
-
 from smogon_vgc_mcp.fetcher.champions_pokemon_list import (
     ALL_POKEMON,
     BASE_POKEMON,
@@ -55,8 +54,7 @@ class TestMegaPokemonList:
         base_slugs = {slug for slug, _ in BASE_POKEMON}
         for mega_slug, _, base_slug in MEGA_POKEMON:
             assert base_slug in base_slugs, (
-                f"Mega form '{mega_slug}' has base_slug '{base_slug}' "
-                f"not found in BASE_POKEMON"
+                f"Mega form '{mega_slug}' has base_slug '{base_slug}' not found in BASE_POKEMON"
             )
 
     def test_no_duplicate_mega_slugs(self):

--- a/tests/test_champions_pokemon_list.py
+++ b/tests/test_champions_pokemon_list.py
@@ -1,6 +1,5 @@
 """Tests for fetcher/champions_pokemon_list.py — static Champions Pokemon list."""
 
-import pytest
 
 from smogon_vgc_mcp.fetcher.champions_pokemon_list import (
     ALL_POKEMON,

--- a/tests/test_database_models.py
+++ b/tests/test_database_models.py
@@ -2,9 +2,9 @@
 
 from smogon_vgc_mcp.database.models import (
     AbilityUsage,
-    CheckCounter,
     ChampionsDexMove,
     ChampionsDexPokemon,
+    CheckCounter,
     DexAbility,
     DexItem,
     DexMove,

--- a/tests/test_fetcher_serebii_parser.py
+++ b/tests/test_fetcher_serebii_parser.py
@@ -1,6 +1,5 @@
 """Tests for fetcher/champions_dex.py — Serebii Champions HTML parser."""
 
-
 from smogon_vgc_mcp.fetcher.champions_dex import parse_serebii_pokemon_page
 
 # ---------------------------------------------------------------------------
@@ -300,9 +299,16 @@ class TestReturnSchema:
     """Tests that the returned dict has all expected keys."""
 
     EXPECTED_KEYS = {
-        "id", "num", "name", "types",
-        "base_stats", "abilities", "ability_hidden",
-        "height_m", "weight_kg", "mega_forms",
+        "id",
+        "num",
+        "name",
+        "types",
+        "base_stats",
+        "abilities",
+        "ability_hidden",
+        "height_m",
+        "weight_kg",
+        "mega_forms",
     }
 
     def test_all_keys_present(self):

--- a/tests/test_fetcher_serebii_parser.py
+++ b/tests/test_fetcher_serebii_parser.py
@@ -1,9 +1,7 @@
 """Tests for fetcher/champions_dex.py — Serebii Champions HTML parser."""
 
-import pytest
 
 from smogon_vgc_mcp.fetcher.champions_dex import parse_serebii_pokemon_page
-
 
 # ---------------------------------------------------------------------------
 # HTML fixtures: minimal but realistic fragments modelled after the real

--- a/uv.lock
+++ b/uv.lock
@@ -62,6 +62,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1028,6 +1041,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "anthropic" },
+    { name = "beautifulsoup4" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "tenacity" },
@@ -1051,6 +1065,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.9.0" },
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40.0" },
@@ -1074,6 +1089,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `beautifulsoup4>=4.12` dependency required by `fetcher/champions_dex.py` (Serebii HTML parser)
- Cleans up unused test imports and ruff import ordering in 4 files
- Checks in `tests/fixtures/serebii_charizard.html` used by the Serebii parser tests
- Captures the three Champions council planning documents under `docs/superpowers/plans/`
- Extends `.gitignore` to keep local agent/workflow state out of the tree (`.claire/`, `.claude/council/sessions/`, `memory/`, `.npmrc`)

## Test plan
- [x] `uv run pytest tests/test_champions_pokemon_list.py tests/test_database_models.py tests/test_fetcher_serebii_parser.py` — 74 passed
- [x] `uv run ruff check` — clean on all files touched by this PR
- [ ] CI green on the full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)