### PR TITLE
feat: Champions team ingestion pipeline (Phase 1+2)

### DIFF
--- a/docs/superpowers/plans/2026-04-22-champions-team-ingestion-phase1-2.md
+++ b/docs/superpowers/plans/2026-04-22-champions-team-ingestion-phase1-2.md
@@ -1,0 +1,2090 @@
+# Champions Team Ingestion — Phase 1+2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a working Champions team ingestion pipeline for Tier-1 (pokepaste) URLs, seeded by the Champions Google Sheet tab, with deterministic validator + normalizer foundation that Tiers 2/3 will build on.
+
+**Architecture:** Parallel `champions_teams` / `champions_team_pokemon` tables with Stat Points (SP) storage. Classifier routes URLs to tier handlers; handlers produce `ChampionsTeamDraft` objects; normalizer + validator decide auto-write vs. queue-for-review. Sheet extension branches on URL shape so pokepaste rows auto-land while X/blog rows get queued as `parse_failed` until later phases.
+
+**Tech Stack:** Python 3.11+, aiosqlite, existing `fetch_text_resilient`, pytest-asyncio, ruff. No new external deps this phase.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-champions-team-ingestion-design.md`
+
+**Scope:** Phases 1 (foundation) + 2 (Tier 1 + sheet + reactive CLI) from the spec. Phases 3 (Tier 2), 4 (Tier 3 + X + blog), 5 (audit), 6 (labeler queue) will each get their own plan after this ships.
+
+---
+
+## File Map
+
+**New files:**
+- `src/smogon_vgc_mcp/database/champions_team_queries.py` — CRUD + write-or-queue routing
+- `src/smogon_vgc_mcp/fetcher/ingestion/__init__.py` — package marker (empty)
+- `src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py` — alias + fuzzy-match pass
+- `src/smogon_vgc_mcp/fetcher/ingestion/validator.py` — ValidationReport + checks
+- `src/smogon_vgc_mcp/fetcher/ingestion/classifier.py` — URL → Tier enum
+- `src/smogon_vgc_mcp/fetcher/ingestion/tier1_pokepaste.py` — Tier 1 handler
+- `src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py` — orchestrator
+- `src/smogon_vgc_mcp/entry/ingest_cli.py` — `vgc-ingest <url>` CLI
+- `tests/test_champions_team_schema.py`
+- `tests/test_ingestion_normalizer.py`
+- `tests/test_ingestion_validator.py`
+- `tests/test_ingestion_classifier.py`
+- `tests/test_ingestion_tier1.py`
+- `tests/test_ingestion_pipeline.py`
+- `tests/test_champions_team_queries.py`
+- `tests/test_ingestion_cli.py`
+- `tests/fixtures/champions_pokepaste_sample.txt`
+
+**Modified files:**
+- `src/smogon_vgc_mcp/database/schema.py` — add migration function + tables + register in `init_database`
+- `src/smogon_vgc_mcp/database/models.py` — add `ChampionsTeam` + `ChampionsTeamPokemon`
+- `src/smogon_vgc_mcp/formats.py` — set `champions_ma.sheet_gid = "791705272"`
+- `src/smogon_vgc_mcp/fetcher/sheets.py` — add `ingest_champions_sheet` that branches by URL shape
+- `pyproject.toml` — add `vgc-ingest` console script entry
+
+---
+
+## Task 1: Schema + migration for `champions_teams` / `champions_team_pokemon`
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/database/schema.py`
+- Create: `tests/test_champions_team_schema.py`
+
+- [ ] **Step 1: Write the failing schema test**
+
+Create `tests/test_champions_team_schema.py`:
+
+```python
+from pathlib import Path
+
+import pytest
+from smogon_vgc_mcp.database.schema import get_connection, init_database
+
+
+@pytest.fixture
+async def db(tmp_path: Path):
+    db_path = tmp_path / "test.db"
+    await init_database(db_path)
+    async with get_connection(db_path) as conn:
+        yield conn
+
+
+async def test_champions_teams_table_created(db):
+    async with db.execute("PRAGMA table_info(champions_teams)") as cur:
+        cols = {row[1] for row in await cur.fetchall()}
+    assert {
+        "id", "format", "team_id", "description", "owner",
+        "source_type", "source_url", "ingestion_status",
+        "confidence_score", "review_reasons", "normalizations", "ingested_at",
+    } <= cols
+
+
+async def test_champions_team_pokemon_table_created(db):
+    async with db.execute("PRAGMA table_info(champions_team_pokemon)") as cur:
+        cols = {row[1] for row in await cur.fetchall()}
+    assert {
+        "id", "team_id", "slot", "pokemon", "item", "ability", "nature",
+        "tera_type", "level",
+        "sp_hp", "sp_atk", "sp_def", "sp_spa", "sp_spd", "sp_spe",
+        "move1", "move2", "move3", "move4",
+    } <= cols
+
+
+async def test_sp_constraints_enforced(db):
+    await db.execute(
+        "INSERT INTO champions_teams(format, team_id, source_type, source_url, "
+        "ingestion_status, confidence_score) VALUES "
+        "('champions_ma', 't1', 'pokepaste', 'https://x', 'auto', 1.0)"
+    )
+    # Per-stat > 32 must fail
+    with pytest.raises(Exception):
+        await db.execute(
+            "INSERT INTO champions_team_pokemon(team_id, slot, pokemon, sp_hp) "
+            "VALUES (1, 1, 'Flutter Mane', 33)"
+        )
+
+
+async def test_sp_total_constraint_enforced(db):
+    await db.execute(
+        "INSERT INTO champions_teams(format, team_id, source_type, source_url, "
+        "ingestion_status, confidence_score) VALUES "
+        "('champions_ma', 't2', 'pokepaste', 'https://x', 'auto', 1.0)"
+    )
+    # Sum > 66 must fail: 32 + 32 + 10 = 74
+    with pytest.raises(Exception):
+        await db.execute(
+            "INSERT INTO champions_team_pokemon(team_id, slot, pokemon, "
+            "sp_hp, sp_atk, sp_def) VALUES (1, 1, 'Koraidon', 32, 32, 10)"
+        )
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+uv run pytest tests/test_champions_team_schema.py -v
+```
+Expected: FAIL — tables don't exist.
+
+- [ ] **Step 3: Add schema DDL + migration**
+
+Append to `src/smogon_vgc_mcp/database/schema.py` (before `async def init_database`):
+
+```python
+CHAMPIONS_TEAMS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS champions_teams (
+    id INTEGER PRIMARY KEY,
+    format TEXT NOT NULL DEFAULT 'champions_ma',
+    team_id TEXT NOT NULL,
+    description TEXT,
+    owner TEXT,
+    source_type TEXT NOT NULL,
+    source_url TEXT NOT NULL,
+    ingestion_status TEXT NOT NULL,
+    confidence_score REAL NOT NULL,
+    review_reasons TEXT,
+    normalizations TEXT,
+    ingested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(format, team_id)
+);
+
+CREATE TABLE IF NOT EXISTS champions_team_pokemon (
+    id INTEGER PRIMARY KEY,
+    team_id INTEGER NOT NULL REFERENCES champions_teams(id) ON DELETE CASCADE,
+    slot INTEGER NOT NULL,
+    pokemon TEXT NOT NULL,
+    item TEXT,
+    ability TEXT,
+    nature TEXT,
+    tera_type TEXT,
+    level INTEGER DEFAULT 50,
+    sp_hp INTEGER DEFAULT 0,
+    sp_atk INTEGER DEFAULT 0,
+    sp_def INTEGER DEFAULT 0,
+    sp_spa INTEGER DEFAULT 0,
+    sp_spd INTEGER DEFAULT 0,
+    sp_spe INTEGER DEFAULT 0,
+    move1 TEXT,
+    move2 TEXT,
+    move3 TEXT,
+    move4 TEXT,
+    UNIQUE(team_id, slot),
+    CHECK(sp_hp BETWEEN 0 AND 32),
+    CHECK(sp_atk BETWEEN 0 AND 32),
+    CHECK(sp_def BETWEEN 0 AND 32),
+    CHECK(sp_spa BETWEEN 0 AND 32),
+    CHECK(sp_spd BETWEEN 0 AND 32),
+    CHECK(sp_spe BETWEEN 0 AND 32),
+    CHECK(sp_hp + sp_atk + sp_def + sp_spa + sp_spd + sp_spe <= 66),
+    CHECK(slot BETWEEN 1 AND 6)
+);
+
+CREATE INDEX IF NOT EXISTS idx_champions_teams_format ON champions_teams(format);
+CREATE INDEX IF NOT EXISTS idx_champions_teams_source ON champions_teams(source_type);
+CREATE INDEX IF NOT EXISTS idx_champions_teams_status ON champions_teams(ingestion_status);
+CREATE INDEX IF NOT EXISTS idx_champions_team_pokemon_pokemon ON champions_team_pokemon(pokemon);
+CREATE INDEX IF NOT EXISTS idx_champions_team_pokemon_team_id ON champions_team_pokemon(team_id);
+"""
+
+
+async def migrate_add_champions_teams_tables(db: aiosqlite.Connection) -> None:
+    """Create champions_teams + champions_team_pokemon. Safe on every startup."""
+    await db.executescript(CHAMPIONS_TEAMS_SCHEMA)
+    await db.commit()
+```
+
+Then inside `init_database(...)`, after the existing migration calls, add:
+
+```python
+    await migrate_add_champions_teams_tables(db)
+```
+
+Also at the top of `init_database` where foreign keys are enabled, ensure `PRAGMA foreign_keys = ON` is set (it already is for aiosqlite default — verify and leave).
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+uv run pytest tests/test_champions_team_schema.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/database/schema.py tests/test_champions_team_schema.py
+git commit -m "feat(db): champions_teams + champions_team_pokemon tables with SP constraints"
+```
+
+---
+
+## Task 2: Data models — `ChampionsTeam`, `ChampionsTeamPokemon`, `ChampionsTeamDraft`
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/database/models.py`
+- Test: inline type check via the query tests in Task 8
+
+- [ ] **Step 1: Add dataclasses**
+
+Append to `src/smogon_vgc_mcp/database/models.py`:
+
+```python
+@dataclass
+class ChampionsTeamPokemon:
+    """A Pokemon on a Champions team (Stat Points, not EVs/IVs)."""
+
+    slot: int
+    pokemon: str
+    item: str | None = None
+    ability: str | None = None
+    nature: str | None = None
+    tera_type: str | None = None
+    level: int = 50
+    sp_hp: int = 0
+    sp_atk: int = 0
+    sp_def: int = 0
+    sp_spa: int = 0
+    sp_spd: int = 0
+    sp_spe: int = 0
+    move1: str | None = None
+    move2: str | None = None
+    move3: str | None = None
+    move4: str | None = None
+
+
+@dataclass
+class ChampionsTeam:
+    """A Champions team as stored in champions_teams."""
+
+    team_id: str
+    source_type: str              # 'sheet' | 'pokepaste' | 'x' | 'blog'
+    source_url: str
+    ingestion_status: str         # 'auto' | 'review_pending' | 'labeled' | 'fetch_failed' | 'parse_failed'
+    confidence_score: float
+    format: str = "champions_ma"
+    description: str | None = None
+    owner: str | None = None
+    review_reasons: list[str] | None = None
+    normalizations: list[str] | None = None
+    pokemon: list[ChampionsTeamPokemon] = field(default_factory=list)
+
+
+@dataclass
+class ChampionsTeamDraft:
+    """In-flight team from an extractor before validation/write."""
+
+    source_type: str
+    source_url: str
+    tier_baseline_confidence: float
+    description: str | None = None
+    owner: str | None = None
+    pokemon: list[ChampionsTeamPokemon] = field(default_factory=list)
+```
+
+Ensure `from dataclasses import dataclass, field` is in the imports.
+
+- [ ] **Step 2: Run existing model tests**
+
+```bash
+uv run pytest tests/ -q --ignore=tests/integration -k "model"
+```
+Expected: PASS (no regressions).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/database/models.py
+git commit -m "feat(models): ChampionsTeam/ChampionsTeamPokemon/ChampionsTeamDraft dataclasses"
+```
+
+---
+
+## Task 3: `ValidationReport` + SP numeric checks
+
+**Files:**
+- Create: `src/smogon_vgc_mcp/fetcher/ingestion/__init__.py` (empty)
+- Create: `src/smogon_vgc_mcp/fetcher/ingestion/validator.py`
+- Create: `tests/test_ingestion_validator.py`
+
+- [ ] **Step 1: Write failing tests for SP checks**
+
+Create `tests/test_ingestion_validator.py`:
+
+```python
+from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
+from smogon_vgc_mcp.fetcher.ingestion.validator import validate
+
+
+def _draft(*pokes: ChampionsTeamPokemon) -> ChampionsTeamDraft:
+    return ChampionsTeamDraft(
+        source_type="pokepaste",
+        source_url="https://pokepast.es/x",
+        tier_baseline_confidence=1.0,
+        pokemon=list(pokes),
+    )
+
+
+def test_valid_team_passes():
+    rep = validate(_draft(ChampionsTeamPokemon(slot=1, pokemon="Koraidon", sp_atk=32, sp_spe=32)))
+    assert rep.passed
+    assert rep.hard_failures == []
+
+
+def test_sp_over_per_stat_flagged():
+    rep = validate(_draft(ChampionsTeamPokemon(slot=1, pokemon="X", sp_atk=33)))
+    assert not rep.passed
+    assert "sp_over_per_stat" in rep.hard_failures
+
+
+def test_sp_over_total_flagged():
+    rep = validate(_draft(ChampionsTeamPokemon(
+        slot=1, pokemon="X", sp_hp=32, sp_atk=32, sp_def=10,
+    )))
+    assert not rep.passed
+    assert "sp_over_total" in rep.hard_failures
+
+
+def test_sp_negative_flagged():
+    rep = validate(_draft(ChampionsTeamPokemon(slot=1, pokemon="X", sp_atk=-1)))
+    assert not rep.passed
+    assert "sp_negative" in rep.hard_failures
+
+
+def test_boundary_32_ok():
+    rep = validate(_draft(ChampionsTeamPokemon(slot=1, pokemon="X", sp_atk=32)))
+    assert "sp_over_per_stat" not in rep.hard_failures
+
+
+def test_boundary_66_total_ok():
+    # 11 each across 6 stats = 66
+    rep = validate(_draft(ChampionsTeamPokemon(
+        slot=1, pokemon="X",
+        sp_hp=11, sp_atk=11, sp_def=11, sp_spa=11, sp_spd=11, sp_spe=11,
+    )))
+    assert "sp_over_total" not in rep.hard_failures
+```
+
+- [ ] **Step 2: Run — expect ImportError**
+
+```bash
+uv run pytest tests/test_ingestion_validator.py -v
+```
+Expected: FAIL (`ModuleNotFoundError: smogon_vgc_mcp.fetcher.ingestion`).
+
+- [ ] **Step 3: Implement validator module**
+
+Create `src/smogon_vgc_mcp/fetcher/ingestion/__init__.py` (empty file).
+
+Create `src/smogon_vgc_mcp/fetcher/ingestion/validator.py`:
+
+```python
+"""Deterministic validator for Champions team drafts.
+
+Runs on every extracted team. Pure functions — no network, no LLM.
+Emits a ValidationReport with hard/soft failure reason codes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
+
+SP_PER_STAT_MAX = 32
+SP_TOTAL_MAX = 66
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    passed: bool
+    hard_failures: list[str] = field(default_factory=list)
+    soft_failures: list[str] = field(default_factory=list)
+    normalizations: list[str] = field(default_factory=list)
+
+
+def _check_sp_numeric(poke: ChampionsTeamPokemon) -> list[str]:
+    """Return list of reason codes for this Pokemon's SP values."""
+    sp_values = [poke.sp_hp, poke.sp_atk, poke.sp_def, poke.sp_spa, poke.sp_spd, poke.sp_spe]
+    reasons: list[str] = []
+    if any(v < 0 for v in sp_values):
+        reasons.append("sp_negative")
+    if any(v > SP_PER_STAT_MAX for v in sp_values):
+        reasons.append("sp_over_per_stat")
+    if sum(sp_values) > SP_TOTAL_MAX:
+        reasons.append("sp_over_total")
+    return reasons
+
+
+def validate(draft: ChampionsTeamDraft) -> ValidationReport:
+    """Validate a team draft. Returns a ValidationReport."""
+    hard: list[str] = []
+    soft: list[str] = []
+
+    for poke in draft.pokemon:
+        for code in _check_sp_numeric(poke):
+            if code not in hard:
+                hard.append(code)
+
+    return ValidationReport(
+        passed=not hard,
+        hard_failures=hard,
+        soft_failures=soft,
+    )
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+uv run pytest tests/test_ingestion_validator.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/ingestion/__init__.py src/smogon_vgc_mcp/fetcher/ingestion/validator.py tests/test_ingestion_validator.py
+git commit -m "feat(validator): ValidationReport + SP numeric checks (per-stat, total, negative)"
+```
+
+---
+
+## Task 4: Team-level checks (slot_count, duplicate_species)
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/fetcher/ingestion/validator.py`
+- Modify: `tests/test_ingestion_validator.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_ingestion_validator.py`:
+
+```python
+def test_empty_team_flagged():
+    rep = validate(_draft())
+    assert "slot_count" in rep.hard_failures
+
+
+def test_seven_slots_flagged():
+    pokes = [ChampionsTeamPokemon(slot=i, pokemon=f"P{i}") for i in range(1, 8)]
+    rep = validate(_draft(*pokes))
+    assert "slot_count" in rep.hard_failures
+
+
+def test_six_slots_ok():
+    pokes = [ChampionsTeamPokemon(slot=i, pokemon=f"P{i}") for i in range(1, 7)]
+    rep = validate(_draft(*pokes))
+    assert "slot_count" not in rep.hard_failures
+
+
+def test_duplicate_species_flagged():
+    rep = validate(_draft(
+        ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"),
+        ChampionsTeamPokemon(slot=2, pokemon="Flutter Mane"),
+    ))
+    assert "duplicate_species" in rep.hard_failures
+
+
+def test_species_clause_case_insensitive():
+    rep = validate(_draft(
+        ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"),
+        ChampionsTeamPokemon(slot=2, pokemon="flutter mane"),
+    ))
+    assert "duplicate_species" in rep.hard_failures
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```bash
+uv run pytest tests/test_ingestion_validator.py -v
+```
+Expected: new tests FAIL.
+
+- [ ] **Step 3: Implement team-level checks**
+
+Modify `src/smogon_vgc_mcp/fetcher/ingestion/validator.py`. Replace the `validate` function with:
+
+```python
+def _check_team_shape(pokes: list[ChampionsTeamPokemon]) -> list[str]:
+    reasons: list[str] = []
+    if not (1 <= len(pokes) <= 6):
+        reasons.append("slot_count")
+    names_cf = [p.pokemon.casefold() for p in pokes]
+    if len(set(names_cf)) != len(names_cf):
+        reasons.append("duplicate_species")
+    return reasons
+
+
+def validate(draft: ChampionsTeamDraft) -> ValidationReport:
+    """Validate a team draft. Returns a ValidationReport."""
+    hard: list[str] = []
+    soft: list[str] = []
+
+    for code in _check_team_shape(draft.pokemon):
+        if code not in hard:
+            hard.append(code)
+
+    for poke in draft.pokemon:
+        for code in _check_sp_numeric(poke):
+            if code not in hard:
+                hard.append(code)
+
+    return ValidationReport(
+        passed=not hard,
+        hard_failures=hard,
+        soft_failures=soft,
+    )
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+uv run pytest tests/test_ingestion_validator.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/ingestion/validator.py tests/test_ingestion_validator.py
+git commit -m "feat(validator): slot_count + duplicate_species team-level checks"
+```
+
+---
+
+## Task 5: Dex-dependent checks (pokemon_unknown, ability_illegal, move_illegal)
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/fetcher/ingestion/validator.py`
+- Modify: `tests/test_ingestion_validator.py`
+
+- [ ] **Step 1: Write failing tests with fake dex lookup**
+
+Append to `tests/test_ingestion_validator.py`:
+
+```python
+FAKE_DEX = {
+    "flutter mane": {
+        "abilities": ["Protosynthesis"],
+        "moves": ["Moonblast", "Shadow Ball", "Protect", "Dazzling Gleam", "Icy Wind"],
+    },
+    "koraidon": {
+        "abilities": ["Orichalcum Pulse"],
+        "moves": ["Flare Blitz", "Collision Course", "Protect", "Dragon Claw"],
+    },
+}
+
+
+def test_pokemon_unknown_flagged():
+    rep = validate(
+        _draft(ChampionsTeamPokemon(slot=1, pokemon="Fake Pokemon")),
+        dex_lookup=FAKE_DEX,
+    )
+    assert "pokemon_unknown" in rep.hard_failures
+
+
+def test_ability_illegal_flagged_as_soft():
+    rep = validate(
+        _draft(ChampionsTeamPokemon(
+            slot=1, pokemon="Flutter Mane", ability="Levitate",
+        )),
+        dex_lookup=FAKE_DEX,
+    )
+    assert "ability_illegal" in rep.soft_failures
+    assert rep.passed  # soft failures don't fail the report
+
+
+def test_move_illegal_flagged_as_soft():
+    rep = validate(
+        _draft(ChampionsTeamPokemon(
+            slot=1, pokemon="Flutter Mane",
+            move1="Flare Blitz",  # not in Flutter Mane learnset
+        )),
+        dex_lookup=FAKE_DEX,
+    )
+    assert "move_illegal" in rep.soft_failures
+
+
+def test_legal_ability_and_moves_ok():
+    rep = validate(
+        _draft(ChampionsTeamPokemon(
+            slot=1, pokemon="Flutter Mane",
+            ability="Protosynthesis",
+            move1="Moonblast", move2="Shadow Ball", move3="Protect", move4="Icy Wind",
+        )),
+        dex_lookup=FAKE_DEX,
+    )
+    assert "ability_illegal" not in rep.soft_failures
+    assert "move_illegal" not in rep.soft_failures
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```bash
+uv run pytest tests/test_ingestion_validator.py -v
+```
+Expected: new tests FAIL (`dex_lookup` kwarg unknown).
+
+- [ ] **Step 3: Implement dex-dependent checks**
+
+Modify `src/smogon_vgc_mcp/fetcher/ingestion/validator.py`. Extend `validate` and add helpers:
+
+```python
+DexLookup = dict[str, dict[str, list[str]]]  # name_casefold -> {"abilities": [...], "moves": [...]}
+
+
+def _check_pokemon_identity(poke: ChampionsTeamPokemon, dex: DexLookup | None) -> list[str]:
+    if dex is None:
+        return []
+    if poke.pokemon.casefold() not in dex:
+        return ["pokemon_unknown"]
+    return []
+
+
+def _check_ability_and_moves(
+    poke: ChampionsTeamPokemon, dex: DexLookup | None
+) -> list[str]:
+    if dex is None:
+        return []
+    entry = dex.get(poke.pokemon.casefold())
+    if entry is None:
+        return []
+    soft: list[str] = []
+    if poke.ability and poke.ability not in entry["abilities"]:
+        soft.append("ability_illegal")
+    moves = [poke.move1, poke.move2, poke.move3, poke.move4]
+    for move in moves:
+        if move and move not in entry["moves"]:
+            soft.append("move_illegal")
+            break
+    return soft
+
+
+def validate(
+    draft: ChampionsTeamDraft,
+    *,
+    dex_lookup: DexLookup | None = None,
+) -> ValidationReport:
+    hard: list[str] = []
+    soft: list[str] = []
+
+    for code in _check_team_shape(draft.pokemon):
+        if code not in hard:
+            hard.append(code)
+
+    for poke in draft.pokemon:
+        for code in _check_sp_numeric(poke):
+            if code not in hard:
+                hard.append(code)
+        for code in _check_pokemon_identity(poke, dex_lookup):
+            if code not in hard:
+                hard.append(code)
+        for code in _check_ability_and_moves(poke, dex_lookup):
+            if code not in soft:
+                soft.append(code)
+
+    return ValidationReport(
+        passed=not hard,
+        hard_failures=hard,
+        soft_failures=soft,
+    )
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+uv run pytest tests/test_ingestion_validator.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/ingestion/validator.py tests/test_ingestion_validator.py
+git commit -m "feat(validator): dex-dependent checks (pokemon_unknown, ability_illegal, move_illegal)"
+```
+
+---
+
+## Task 6: Vocabulary + move count checks
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/fetcher/ingestion/validator.py`
+- Modify: `tests/test_ingestion_validator.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_ingestion_validator.py`:
+
+```python
+def test_nature_unknown_soft():
+    rep = validate(_draft(
+        ChampionsTeamPokemon(slot=1, pokemon="X", nature="Weird"),
+    ))
+    assert "nature_unknown" in rep.soft_failures
+
+
+def test_nature_known_ok():
+    rep = validate(_draft(
+        ChampionsTeamPokemon(slot=1, pokemon="X", nature="Timid"),
+    ))
+    assert "nature_unknown" not in rep.soft_failures
+
+
+def test_tera_type_unknown_soft():
+    rep = validate(_draft(
+        ChampionsTeamPokemon(slot=1, pokemon="X", tera_type="Banana"),
+    ))
+    assert "tera_type_unknown" in rep.soft_failures
+
+
+def test_tera_type_none_ok():
+    rep = validate(_draft(
+        ChampionsTeamPokemon(slot=1, pokemon="X", tera_type=None),
+    ))
+    assert "tera_type_unknown" not in rep.soft_failures
+
+
+def test_move_count_zero_soft():
+    # no moves at all
+    rep = validate(_draft(ChampionsTeamPokemon(slot=1, pokemon="X")))
+    assert "move_count" in rep.soft_failures
+
+
+def test_move_count_four_ok():
+    rep = validate(_draft(ChampionsTeamPokemon(
+        slot=1, pokemon="X",
+        move1="a", move2="b", move3="c", move4="d",
+    )))
+    assert "move_count" not in rep.soft_failures
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```bash
+uv run pytest tests/test_ingestion_validator.py -v
+```
+Expected: new tests FAIL.
+
+- [ ] **Step 3: Implement vocabulary + move count checks**
+
+Append constants and extend `validate` in `src/smogon_vgc_mcp/fetcher/ingestion/validator.py`:
+
+```python
+NATURES = frozenset({
+    "Hardy", "Lonely", "Brave", "Adamant", "Naughty",
+    "Bold", "Docile", "Relaxed", "Impish", "Lax",
+    "Timid", "Hasty", "Serious", "Jolly", "Naive",
+    "Modest", "Mild", "Quiet", "Bashful", "Rash",
+    "Calm", "Gentle", "Sassy", "Careful", "Quirky",
+})
+
+TYPES = frozenset({
+    "Normal", "Fire", "Water", "Electric", "Grass", "Ice",
+    "Fighting", "Poison", "Ground", "Flying", "Psychic", "Bug",
+    "Rock", "Ghost", "Dragon", "Dark", "Steel", "Fairy",
+})
+
+
+def _check_vocab_and_moves(poke: ChampionsTeamPokemon) -> list[str]:
+    soft: list[str] = []
+    if poke.nature is not None and poke.nature not in NATURES:
+        soft.append("nature_unknown")
+    if poke.tera_type is not None and poke.tera_type not in TYPES:
+        soft.append("tera_type_unknown")
+    moves = [m for m in (poke.move1, poke.move2, poke.move3, poke.move4) if m]
+    if not (1 <= len(moves) <= 4):
+        soft.append("move_count")
+    return soft
+```
+
+Then in `validate`, add after the existing per-poke loop body:
+
+```python
+        for code in _check_vocab_and_moves(poke):
+            if code not in soft:
+                soft.append(code)
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+uv run pytest tests/test_ingestion_validator.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/ingestion/validator.py tests/test_ingestion_validator.py
+git commit -m "feat(validator): vocabulary + move_count soft checks"
+```
+
+---
+
+## Task 7: Normalizer (Pokemon aliases, move fuzzy, nature/tera title-case)
+
+**Files:**
+- Create: `src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py`
+- Create: `tests/test_ingestion_normalizer.py`
+
+- [ ] **Step 1: Write failing normalizer tests**
+
+Create `tests/test_ingestion_normalizer.py`:
+
+```python
+from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
+from smogon_vgc_mcp.fetcher.ingestion.normalizer import normalize
+
+
+def _draft(*pokes: ChampionsTeamPokemon) -> ChampionsTeamDraft:
+    return ChampionsTeamDraft(
+        source_type="pokepaste",
+        source_url="https://x",
+        tier_baseline_confidence=1.0,
+        pokemon=list(pokes),
+    )
+
+
+def test_pokemon_alias_expanded():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="urshifu-s"))
+    normed, log = normalize(d)
+    assert normed.pokemon[0].pokemon == "Urshifu-Single-Strike"
+    assert any("pokemon_alias" in entry for entry in log)
+
+
+def test_move_fuzzy_match_distance_2():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", move1="Close Combatt"))
+    known_moves = {"Close Combat", "Moonblast", "Protect"}
+    normed, log = normalize(d, known_moves=known_moves)
+    assert normed.pokemon[0].move1 == "Close Combat"
+    assert any("move_fuzzy" in entry for entry in log)
+
+
+def test_move_fuzzy_no_match_left_alone():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", move1="Completely Unknown"))
+    normed, log = normalize(d, known_moves={"Close Combat"})
+    assert normed.pokemon[0].move1 == "Completely Unknown"
+
+
+def test_nature_title_case():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", nature="timid"))
+    normed, log = normalize(d)
+    assert normed.pokemon[0].nature == "Timid"
+
+
+def test_tera_title_case():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", tera_type="fairy"))
+    normed, log = normalize(d)
+    assert normed.pokemon[0].tera_type == "Fairy"
+
+
+def test_item_strip_consumed():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", item="Focus Sash (consumed)"))
+    normed, log = normalize(d)
+    assert normed.pokemon[0].item == "Focus Sash"
+```
+
+- [ ] **Step 2: Run — expect ImportError**
+
+```bash
+uv run pytest tests/test_ingestion_normalizer.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement normalizer**
+
+Create `src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py`:
+
+```python
+"""Deterministic normalizer for Champions team drafts.
+
+Runs before the validator. Fixes common surface-level issues (case,
+aliases, whitespace, fuzzy move spelling) and logs every change so
+the audit trail can detect LLM drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
+
+# Minimal alias table — extend as real data exposes gaps. Keys are
+# casefolded inputs; values are canonical Pokemon names in the dex.
+POKEMON_ALIASES: dict[str, str] = {
+    "urshifu-s": "Urshifu-Single-Strike",
+    "urshifu-r": "Urshifu-Rapid-Strike",
+    "ogerpon-w": "Ogerpon-Wellspring",
+    "ogerpon-h": "Ogerpon-Hearthflame",
+    "ogerpon-c": "Ogerpon-Cornerstone",
+    "landorus-t": "Landorus-Therian",
+    "landorus-i": "Landorus-Incarnate",
+}
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Classic iterative Levenshtein distance."""
+    if len(a) < len(b):
+        a, b = b, a
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        curr = [i]
+        for j, cb in enumerate(b, start=1):
+            ins = curr[j - 1] + 1
+            dele = prev[j] + 1
+            sub = prev[j - 1] + (0 if ca == cb else 1)
+            curr.append(min(ins, dele, sub))
+        prev = curr
+    return prev[-1]
+
+
+def _closest_move(name: str, known: set[str]) -> str | None:
+    """Return the closest known move within distance 2, else None."""
+    best: tuple[int, str] | None = None
+    for known_name in known:
+        d = _levenshtein(name.casefold(), known_name.casefold())
+        if d <= 2 and (best is None or d < best[0]):
+            best = (d, known_name)
+    return best[1] if best else None
+
+
+def _normalize_pokemon(
+    poke: ChampionsTeamPokemon,
+    *,
+    known_moves: set[str] | None,
+    log: list[str],
+) -> ChampionsTeamPokemon:
+    updates: dict[str, object] = {}
+
+    alias = POKEMON_ALIASES.get(poke.pokemon.casefold())
+    if alias and alias != poke.pokemon:
+        log.append(f"pokemon_alias:{poke.pokemon}->{alias}")
+        updates["pokemon"] = alias
+
+    if poke.nature:
+        title = poke.nature.strip().title()
+        if title != poke.nature:
+            log.append(f"nature_case:{poke.nature}->{title}")
+            updates["nature"] = title
+
+    if poke.tera_type:
+        title = poke.tera_type.strip().title()
+        if title != poke.tera_type:
+            log.append(f"tera_case:{poke.tera_type}->{title}")
+            updates["tera_type"] = title
+
+    if poke.item and "(consumed)" in poke.item.casefold():
+        stripped = poke.item.replace("(consumed)", "").replace("(Consumed)", "").strip()
+        log.append(f"item_strip_consumed:{poke.item}->{stripped}")
+        updates["item"] = stripped
+
+    if known_moves:
+        for attr in ("move1", "move2", "move3", "move4"):
+            current = getattr(poke, attr)
+            if not current or current in known_moves:
+                continue
+            fixed = _closest_move(current, known_moves)
+            if fixed and fixed != current:
+                log.append(f"move_fuzzy:{current}->{fixed}")
+                updates[attr] = fixed
+
+    if not updates:
+        return poke
+    return replace(poke, **updates)
+
+
+def normalize(
+    draft: ChampionsTeamDraft,
+    *,
+    known_moves: set[str] | None = None,
+) -> tuple[ChampionsTeamDraft, list[str]]:
+    """Return a normalized copy of the draft plus a list of change entries."""
+    log: list[str] = []
+    new_pokes = [
+        _normalize_pokemon(p, known_moves=known_moves, log=log) for p in draft.pokemon
+    ]
+    return replace(draft, pokemon=new_pokes), log
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+uv run pytest tests/test_ingestion_normalizer.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py tests/test_ingestion_normalizer.py
+git commit -m "feat(normalizer): pokemon aliases + move fuzzy + case-fold normalization"
+```
+
+---
+
+## Task 8: Champions team queries (insert, write-or-queue, fingerprint)
+
+**Files:**
+- Create: `src/smogon_vgc_mcp/database/champions_team_queries.py`
+- Create: `tests/test_champions_team_queries.py`
+
+- [ ] **Step 1: Write failing query tests**
+
+Create `tests/test_champions_team_queries.py`:
+
+```python
+import json
+from pathlib import Path
+
+import pytest
+from smogon_vgc_mcp.database.champions_team_queries import (
+    compute_team_fingerprint,
+    get_champions_team,
+    write_or_queue_team,
+)
+from smogon_vgc_mcp.database.models import ChampionsTeam, ChampionsTeamPokemon
+from smogon_vgc_mcp.database.schema import get_connection, init_database
+
+
+@pytest.fixture
+async def db_path(tmp_path: Path):
+    p = tmp_path / "test.db"
+    await init_database(p)
+    return p
+
+
+def _team(
+    *pokes: ChampionsTeamPokemon,
+    status: str = "auto",
+    conf: float = 1.0,
+    fingerprint: str = "abc123",
+) -> ChampionsTeam:
+    return ChampionsTeam(
+        team_id=fingerprint,
+        source_type="pokepaste",
+        source_url="https://pokepast.es/abc",
+        ingestion_status=status,
+        confidence_score=conf,
+        pokemon=list(pokes),
+    )
+
+
+async def test_write_auto_team(db_path: Path):
+    team = _team(
+        ChampionsTeamPokemon(slot=1, pokemon="Koraidon", sp_atk=32, sp_spe=32),
+        fingerprint="fp1",
+    )
+    async with get_connection(db_path) as db:
+        row_id = await write_or_queue_team(db, team)
+        assert row_id > 0
+        out = await get_champions_team(db, row_id)
+    assert out is not None
+    assert out.ingestion_status == "auto"
+    assert len(out.pokemon) == 1
+    assert out.pokemon[0].pokemon == "Koraidon"
+
+
+async def test_write_queue_team(db_path: Path):
+    team = _team(
+        ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"),
+        status="review_pending",
+        conf=0.5,
+        fingerprint="fp2",
+    )
+    async with get_connection(db_path) as db:
+        row_id = await write_or_queue_team(db, team)
+        out = await get_champions_team(db, row_id)
+    assert out.ingestion_status == "review_pending"
+    assert out.confidence_score == pytest.approx(0.5)
+
+
+async def test_duplicate_fingerprint_returns_existing(db_path: Path):
+    team = _team(
+        ChampionsTeamPokemon(slot=1, pokemon="Koraidon"),
+        fingerprint="dup",
+    )
+    async with get_connection(db_path) as db:
+        id1 = await write_or_queue_team(db, team)
+        id2 = await write_or_queue_team(db, team)
+    assert id1 == id2
+
+
+async def test_review_reasons_persisted(db_path: Path):
+    team = _team(
+        ChampionsTeamPokemon(slot=1, pokemon="X"),
+        fingerprint="rr",
+    )
+    team.review_reasons = ["sp_over_total"]
+    team.normalizations = ["move_fuzzy:Close Combatt->Close Combat"]
+    async with get_connection(db_path) as db:
+        row_id = await write_or_queue_team(db, team)
+        out = await get_champions_team(db, row_id)
+    assert out.review_reasons == ["sp_over_total"]
+    assert out.normalizations == ["move_fuzzy:Close Combatt->Close Combat"]
+
+
+def test_fingerprint_stable_for_same_team():
+    team_a = _team(ChampionsTeamPokemon(slot=1, pokemon="Koraidon", move1="Flare Blitz"))
+    team_b = _team(ChampionsTeamPokemon(slot=1, pokemon="Koraidon", move1="Flare Blitz"))
+    assert compute_team_fingerprint(team_a.pokemon) == compute_team_fingerprint(team_b.pokemon)
+
+
+def test_fingerprint_move_order_insensitive():
+    team_a = _team(ChampionsTeamPokemon(
+        slot=1, pokemon="X", move1="A", move2="B", move3="C", move4="D"))
+    team_b = _team(ChampionsTeamPokemon(
+        slot=1, pokemon="X", move1="D", move2="C", move3="B", move4="A"))
+    assert compute_team_fingerprint(team_a.pokemon) == compute_team_fingerprint(team_b.pokemon)
+
+
+def test_fingerprint_different_when_sets_differ():
+    team_a = _team(ChampionsTeamPokemon(slot=1, pokemon="Koraidon"))
+    team_b = _team(ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"))
+    assert compute_team_fingerprint(team_a.pokemon) != compute_team_fingerprint(team_b.pokemon)
+```
+
+- [ ] **Step 2: Run — expect ImportError**
+
+```bash
+uv run pytest tests/test_champions_team_queries.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement queries**
+
+Create `src/smogon_vgc_mcp/database/champions_team_queries.py`:
+
+```python
+"""CRUD + routing for Champions teams."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import aiosqlite
+
+from smogon_vgc_mcp.database.models import ChampionsTeam, ChampionsTeamPokemon
+
+
+def compute_team_fingerprint(pokemon: list[ChampionsTeamPokemon]) -> str:
+    """Stable SHA256 of the team's structural content.
+
+    Move order within a set is normalized (sorted) so a team that
+    reorders moves doesn't produce a different fingerprint.
+    """
+    canonical = []
+    for p in sorted(pokemon, key=lambda x: (x.slot, x.pokemon.casefold())):
+        moves = tuple(sorted(m for m in (p.move1, p.move2, p.move3, p.move4) if m))
+        canonical.append(
+            (
+                p.pokemon.casefold(),
+                (p.ability or "").casefold(),
+                (p.item or "").casefold(),
+                (p.nature or "").casefold(),
+                (p.tera_type or "").casefold(),
+                p.level,
+                p.sp_hp, p.sp_atk, p.sp_def, p.sp_spa, p.sp_spd, p.sp_spe,
+                moves,
+            )
+        )
+    digest = hashlib.sha256(json.dumps(canonical, sort_keys=True).encode()).hexdigest()
+    return digest[:16]
+
+
+async def write_or_queue_team(db: aiosqlite.Connection, team: ChampionsTeam) -> int:
+    """Insert the team. Returns the row id. Duplicate (format, team_id) returns existing id."""
+    db.row_factory = aiosqlite.Row
+
+    existing = await db.execute_fetchall(
+        "SELECT id FROM champions_teams WHERE format = ? AND team_id = ?",
+        (team.format, team.team_id),
+    )
+    if existing:
+        return int(existing[0]["id"])
+
+    cursor = await db.execute(
+        """
+        INSERT INTO champions_teams(
+            format, team_id, description, owner, source_type, source_url,
+            ingestion_status, confidence_score, review_reasons, normalizations
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            team.format,
+            team.team_id,
+            team.description,
+            team.owner,
+            team.source_type,
+            team.source_url,
+            team.ingestion_status,
+            team.confidence_score,
+            json.dumps(team.review_reasons) if team.review_reasons else None,
+            json.dumps(team.normalizations) if team.normalizations else None,
+        ),
+    )
+    team_row_id = cursor.lastrowid
+
+    for poke in team.pokemon:
+        await db.execute(
+            """
+            INSERT INTO champions_team_pokemon(
+                team_id, slot, pokemon, item, ability, nature, tera_type, level,
+                sp_hp, sp_atk, sp_def, sp_spa, sp_spd, sp_spe,
+                move1, move2, move3, move4
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                team_row_id, poke.slot, poke.pokemon, poke.item, poke.ability,
+                poke.nature, poke.tera_type, poke.level,
+                poke.sp_hp, poke.sp_atk, poke.sp_def, poke.sp_spa, poke.sp_spd, poke.sp_spe,
+                poke.move1, poke.move2, poke.move3, poke.move4,
+            ),
+        )
+
+    await db.commit()
+    return int(team_row_id)
+
+
+async def get_champions_team(db: aiosqlite.Connection, row_id: int) -> ChampionsTeam | None:
+    db.row_factory = aiosqlite.Row
+    team_row = await db.execute_fetchall(
+        "SELECT * FROM champions_teams WHERE id = ?", (row_id,)
+    )
+    if not team_row:
+        return None
+    t = team_row[0]
+
+    poke_rows = await db.execute_fetchall(
+        "SELECT * FROM champions_team_pokemon WHERE team_id = ? ORDER BY slot",
+        (row_id,),
+    )
+    pokemon = [
+        ChampionsTeamPokemon(
+            slot=p["slot"], pokemon=p["pokemon"], item=p["item"], ability=p["ability"],
+            nature=p["nature"], tera_type=p["tera_type"], level=p["level"],
+            sp_hp=p["sp_hp"], sp_atk=p["sp_atk"], sp_def=p["sp_def"],
+            sp_spa=p["sp_spa"], sp_spd=p["sp_spd"], sp_spe=p["sp_spe"],
+            move1=p["move1"], move2=p["move2"], move3=p["move3"], move4=p["move4"],
+        )
+        for p in poke_rows
+    ]
+
+    return ChampionsTeam(
+        team_id=t["team_id"],
+        format=t["format"],
+        description=t["description"],
+        owner=t["owner"],
+        source_type=t["source_type"],
+        source_url=t["source_url"],
+        ingestion_status=t["ingestion_status"],
+        confidence_score=t["confidence_score"],
+        review_reasons=json.loads(t["review_reasons"]) if t["review_reasons"] else None,
+        normalizations=json.loads(t["normalizations"]) if t["normalizations"] else None,
+        pokemon=pokemon,
+    )
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+uv run pytest tests/test_champions_team_queries.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/database/champions_team_queries.py tests/test_champions_team_queries.py
+git commit -m "feat(db): champions_team_queries with fingerprint dedup"
+```
+
+---
+
+## Task 9: URL classifier + Tier enum
+
+**Files:**
+- Create: `src/smogon_vgc_mcp/fetcher/ingestion/classifier.py`
+- Create: `tests/test_ingestion_classifier.py`
+
+- [ ] **Step 1: Write failing classifier tests**
+
+Create `tests/test_ingestion_classifier.py`:
+
+```python
+import pytest
+from smogon_vgc_mcp.fetcher.ingestion.classifier import Tier, classify_url
+
+
+@pytest.mark.parametrize("url, tier", [
+    ("https://pokepast.es/abc123", Tier.POKEPASTE),
+    ("http://pokepast.es/abc123", Tier.POKEPASTE),
+    ("https://pokepast.es/abc123/raw", Tier.POKEPASTE),
+    ("https://twitter.com/user/status/12345", Tier.X),
+    ("https://x.com/user/status/12345", Tier.X),
+    ("https://mobile.twitter.com/user/status/12345", Tier.X),
+    ("https://nuggetbridge.com/2016/01/foo", Tier.BLOG),
+    ("https://smogon.com/forums/threads/x.12345/", Tier.BLOG),
+    ("https://medium.com/@user/my-team", Tier.BLOG),
+    ("", Tier.UNKNOWN),
+    ("not-a-url", Tier.UNKNOWN),
+    ("ftp://example.com/file", Tier.UNKNOWN),
+])
+def test_classify_url(url: str, tier: Tier):
+    assert classify_url(url) == tier
+```
+
+- [ ] **Step 2: Run — expect ImportError**
+
+```bash
+uv run pytest tests/test_ingestion_classifier.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement classifier**
+
+Create `src/smogon_vgc_mcp/fetcher/ingestion/classifier.py`:
+
+```python
+"""URL shape classifier for the ingestion pipeline."""
+
+from __future__ import annotations
+
+from enum import Enum
+from urllib.parse import urlparse
+
+
+class Tier(Enum):
+    POKEPASTE = "pokepaste"
+    X = "x"
+    BLOG = "blog"
+    UNKNOWN = "unknown"
+
+
+_POKEPASTE_HOSTS = frozenset({"pokepast.es", "www.pokepast.es"})
+_X_HOSTS = frozenset({
+    "twitter.com", "www.twitter.com", "mobile.twitter.com",
+    "x.com", "www.x.com",
+})
+
+
+def classify_url(url: str) -> Tier:
+    """Return the Tier enum for a raw URL string."""
+    if not url:
+        return Tier.UNKNOWN
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return Tier.UNKNOWN
+    if parsed.scheme not in ("http", "https"):
+        return Tier.UNKNOWN
+    host = (parsed.netloc or "").casefold()
+    if host in _POKEPASTE_HOSTS:
+        return Tier.POKEPASTE
+    if host in _X_HOSTS:
+        return Tier.X
+    if host:  # any other http(s) host counts as a generic blog URL
+        return Tier.BLOG
+    return Tier.UNKNOWN
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+uv run pytest tests/test_ingestion_classifier.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/ingestion/classifier.py tests/test_ingestion_classifier.py
+git commit -m "feat(ingestion): URL classifier with Tier enum"
+```
+
+---
+
+## Task 10: Tier 1 pokepaste handler
+
+**Files:**
+- Create: `src/smogon_vgc_mcp/fetcher/ingestion/tier1_pokepaste.py`
+- Create: `tests/fixtures/champions_pokepaste_sample.txt`
+- Create: `tests/test_ingestion_tier1.py`
+
+- [ ] **Step 1: Write failing Tier 1 tests**
+
+Create `tests/fixtures/champions_pokepaste_sample.txt`:
+
+```
+Koraidon @ Life Orb
+Ability: Orichalcum Pulse
+Level: 50
+Tera Type: Fire
+EVs: 32 Atk / 32 Spe
+Adamant Nature
+- Flare Blitz
+- Collision Course
+- Protect
+- Dragon Claw
+
+Flutter Mane @ Focus Sash
+Ability: Protosynthesis
+Level: 50
+Tera Type: Fairy
+EVs: 32 SpA / 32 Spe
+Timid Nature
+- Moonblast
+- Shadow Ball
+- Protect
+- Dazzling Gleam
+```
+
+Note: EVs lines here are used because existing `parse_pokepaste` expects EV syntax. The Tier 1 handler translates EV numbers directly into SP fields — a pokepaste authored for Champions uses the same `32 Atk / 32 Spe` text shape as Gen 9 but the numbers now mean SP.
+
+Create `tests/test_ingestion_tier1.py`:
+
+```python
+from pathlib import Path
+
+import pytest
+from smogon_vgc_mcp.fetcher.ingestion.tier1_pokepaste import (
+    parse_pokepaste_to_champions_draft,
+)
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "champions_pokepaste_sample.txt"
+
+
+def test_tier1_parses_two_pokemon():
+    text = FIXTURE.read_text()
+    draft = parse_pokepaste_to_champions_draft(
+        text, source_url="https://pokepast.es/fixt"
+    )
+    assert len(draft.pokemon) == 2
+    assert draft.pokemon[0].pokemon == "Koraidon"
+    assert draft.pokemon[1].pokemon == "Flutter Mane"
+
+
+def test_tier1_maps_evs_to_sp():
+    text = FIXTURE.read_text()
+    draft = parse_pokepaste_to_champions_draft(
+        text, source_url="https://pokepast.es/fixt"
+    )
+    kor = draft.pokemon[0]
+    assert kor.sp_atk == 32
+    assert kor.sp_spe == 32
+    assert kor.sp_hp == 0
+
+
+def test_tier1_captures_item_ability_nature_tera():
+    text = FIXTURE.read_text()
+    draft = parse_pokepaste_to_champions_draft(
+        text, source_url="https://pokepast.es/fixt"
+    )
+    kor = draft.pokemon[0]
+    assert kor.item == "Life Orb"
+    assert kor.ability == "Orichalcum Pulse"
+    assert kor.nature == "Adamant"
+    assert kor.tera_type == "Fire"
+
+
+def test_tier1_captures_moves():
+    text = FIXTURE.read_text()
+    draft = parse_pokepaste_to_champions_draft(
+        text, source_url="https://pokepast.es/fixt"
+    )
+    kor = draft.pokemon[0]
+    assert kor.move1 == "Flare Blitz"
+    assert kor.move4 == "Dragon Claw"
+
+
+def test_tier1_sets_source_type_and_baseline_confidence():
+    text = FIXTURE.read_text()
+    draft = parse_pokepaste_to_champions_draft(
+        text, source_url="https://pokepast.es/fixt"
+    )
+    assert draft.source_type == "pokepaste"
+    assert draft.tier_baseline_confidence == 1.0
+```
+
+- [ ] **Step 2: Run — expect ImportError**
+
+```bash
+uv run pytest tests/test_ingestion_tier1.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement Tier 1 handler**
+
+Create `src/smogon_vgc_mcp/fetcher/ingestion/tier1_pokepaste.py`:
+
+```python
+"""Tier 1 pokepaste handler for Champions ingestion.
+
+Reuses the existing pokepaste parser and translates its Gen 9 EV
+output directly into Champions SP fields (same numeric values — a
+pokepaste authored for Champions uses identical text syntax but the
+numbers now represent Stat Points).
+"""
+
+from __future__ import annotations
+
+from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
+from smogon_vgc_mcp.fetcher.pokepaste import fetch_pokepaste, parse_pokepaste
+from smogon_vgc_mcp.resilience import FetchResult
+
+
+def parse_pokepaste_to_champions_draft(
+    text: str, *, source_url: str,
+) -> ChampionsTeamDraft:
+    """Parse raw pokepaste text into a ChampionsTeamDraft."""
+    parsed = parse_pokepaste(text)
+    pokemon = [
+        ChampionsTeamPokemon(
+            slot=tp.slot,
+            pokemon=tp.pokemon,
+            item=tp.item,
+            ability=tp.ability,
+            nature=tp.nature,
+            tera_type=tp.tera_type,
+            level=50,
+            sp_hp=tp.hp_ev,
+            sp_atk=tp.atk_ev,
+            sp_def=tp.def_ev,
+            sp_spa=tp.spa_ev,
+            sp_spd=tp.spd_ev,
+            sp_spe=tp.spe_ev,
+            move1=tp.move1,
+            move2=tp.move2,
+            move3=tp.move3,
+            move4=tp.move4,
+        )
+        for tp in parsed
+    ]
+    return ChampionsTeamDraft(
+        source_type="pokepaste",
+        source_url=source_url,
+        tier_baseline_confidence=1.0,
+        pokemon=pokemon,
+    )
+
+
+async def fetch_and_parse_pokepaste(url: str) -> FetchResult[ChampionsTeamDraft]:
+    """Fetch a pokepaste URL and return a ChampionsTeamDraft."""
+    fetched = await fetch_pokepaste(url)
+    if not fetched.success or not fetched.data:
+        return FetchResult.fail(fetched.error) if fetched.error else FetchResult.ok(None)
+    draft = parse_pokepaste_to_champions_draft(fetched.data, source_url=url)
+    return FetchResult.ok(draft)
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+uv run pytest tests/test_ingestion_tier1.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/ingestion/tier1_pokepaste.py tests/fixtures/champions_pokepaste_sample.txt tests/test_ingestion_tier1.py
+git commit -m "feat(ingestion): Tier 1 pokepaste handler mapping EV syntax to SP"
+```
+
+---
+
+## Task 11: Pipeline orchestrator (classify → fetch → normalize → validate → write-or-queue)
+
+**Files:**
+- Create: `src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py`
+- Create: `tests/test_ingestion_pipeline.py`
+
+- [ ] **Step 1: Write failing orchestrator tests**
+
+Create `tests/test_ingestion_pipeline.py`:
+
+```python
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from smogon_vgc_mcp.database.champions_team_queries import get_champions_team
+from smogon_vgc_mcp.database.schema import get_connection, init_database
+from smogon_vgc_mcp.fetcher.ingestion.pipeline import IngestResult, ingest_url
+from smogon_vgc_mcp.resilience import FetchResult
+
+FIXTURE = Path(__file__).parent / "fixtures" / "champions_pokepaste_sample.txt"
+
+
+@pytest.fixture
+async def db_path(tmp_path: Path):
+    p = tmp_path / "test.db"
+    await init_database(p)
+    return p
+
+
+async def test_ingest_unknown_url_returns_rejected(db_path: Path):
+    result = await ingest_url("not-a-url", db_path=db_path)
+    assert result.status == "rejected"
+    assert result.reason == "classifier_unknown_tier"
+    assert result.team_row_id is None
+
+
+async def test_ingest_pokepaste_auto_writes(db_path: Path):
+    text = FIXTURE.read_text()
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.ok(text)),
+    ):
+        result = await ingest_url(
+            "https://pokepast.es/abc", db_path=db_path
+        )
+    assert result.status == "auto"
+    assert result.team_row_id is not None
+    async with get_connection(db_path) as db:
+        stored = await get_champions_team(db, result.team_row_id)
+    assert stored.ingestion_status == "auto"
+    assert stored.confidence_score == pytest.approx(1.0)
+    assert len(stored.pokemon) == 2
+
+
+async def test_ingest_fetch_failure_returns_fetch_failed(db_path: Path):
+    from smogon_vgc_mcp.resilience import ErrorCategory, ServiceError
+
+    err = ServiceError(
+        category=ErrorCategory.HTTP_CLIENT_ERROR,
+        service="pokepaste",
+        message="404",
+        is_recoverable=False,
+    )
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.fail(err)),
+    ):
+        result = await ingest_url(
+            "https://pokepast.es/missing", db_path=db_path
+        )
+    assert result.status == "fetch_failed"
+    assert result.team_row_id is None
+
+
+async def test_ingest_x_and_blog_not_implemented_yet(db_path: Path):
+    result = await ingest_url("https://x.com/u/status/1", db_path=db_path)
+    assert result.status == "rejected"
+    assert result.reason == "tier_not_implemented"
+```
+
+- [ ] **Step 2: Run — expect ImportError**
+
+```bash
+uv run pytest tests/test_ingestion_pipeline.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement pipeline**
+
+Create `src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py`:
+
+```python
+"""Top-level ingestion orchestrator.
+
+Routes a URL through the classifier to the appropriate tier handler,
+then normalizes, validates, and writes (or queues) the result.
+
+Phases 3-6 will register additional tier handlers by extending
+``_TIER_HANDLERS``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from smogon_vgc_mcp.database.champions_team_queries import (
+    compute_team_fingerprint,
+    write_or_queue_team,
+)
+from smogon_vgc_mcp.database.models import ChampionsTeam, ChampionsTeamDraft
+from smogon_vgc_mcp.database.schema import get_connection
+from smogon_vgc_mcp.fetcher.ingestion.classifier import Tier, classify_url
+from smogon_vgc_mcp.fetcher.ingestion.normalizer import normalize
+from smogon_vgc_mcp.fetcher.ingestion.tier1_pokepaste import (
+    parse_pokepaste_to_champions_draft,
+)
+from smogon_vgc_mcp.fetcher.ingestion.validator import validate
+from smogon_vgc_mcp.fetcher.pokepaste import fetch_pokepaste  # re-imported for patchability
+from smogon_vgc_mcp.resilience import FetchResult
+
+AUTO_WRITE_THRESHOLD = 0.85
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    status: str                    # 'auto' | 'review_pending' | 'fetch_failed' | 'parse_failed' | 'rejected'
+    team_row_id: int | None = None
+    confidence: float | None = None
+    reason: str | None = None
+
+
+async def _fetch_tier1(url: str) -> FetchResult[ChampionsTeamDraft]:
+    fetched = await fetch_pokepaste(url)
+    if not fetched.success or not fetched.data:
+        return FetchResult.fail(fetched.error) if fetched.error else FetchResult.ok(None)
+    draft = parse_pokepaste_to_champions_draft(fetched.data, source_url=url)
+    return FetchResult.ok(draft)
+
+
+def _score(draft: ChampionsTeamDraft, soft_count: int) -> float:
+    return max(0.0, draft.tier_baseline_confidence - 0.1 * soft_count)
+
+
+async def ingest_url(url: str, *, db_path: Path | None = None) -> IngestResult:
+    tier = classify_url(url)
+
+    if tier == Tier.UNKNOWN:
+        return IngestResult(status="rejected", reason="classifier_unknown_tier")
+    if tier in (Tier.X, Tier.BLOG):
+        return IngestResult(status="rejected", reason="tier_not_implemented")
+
+    if tier == Tier.POKEPASTE:
+        fetched = await _fetch_tier1(url)
+    else:
+        return IngestResult(status="rejected", reason="tier_not_implemented")
+
+    if not fetched.success:
+        return IngestResult(status="fetch_failed", reason=str(fetched.error))
+    if fetched.data is None:
+        return IngestResult(status="parse_failed", reason="empty_parse")
+
+    draft = fetched.data
+    normalized, norm_log = normalize(draft)
+    report = validate(normalized)
+
+    if report.hard_failures:
+        confidence = 0.0
+    else:
+        confidence = _score(normalized, len(report.soft_failures))
+
+    status = "auto" if confidence >= AUTO_WRITE_THRESHOLD else "review_pending"
+
+    team = ChampionsTeam(
+        team_id=compute_team_fingerprint(normalized.pokemon),
+        source_type=normalized.source_type,
+        source_url=normalized.source_url,
+        ingestion_status=status,
+        confidence_score=confidence,
+        review_reasons=report.hard_failures + report.soft_failures or None,
+        normalizations=norm_log or None,
+        pokemon=normalized.pokemon,
+    )
+
+    async with get_connection(db_path) as db:
+        row_id = await write_or_queue_team(db, team)
+
+    return IngestResult(status=status, team_row_id=row_id, confidence=confidence)
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+uv run pytest tests/test_ingestion_pipeline.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py tests/test_ingestion_pipeline.py
+git commit -m "feat(ingestion): pipeline orchestrator with confidence gate"
+```
+
+---
+
+## Task 12: Champions sheet extension + format config
+
+**Files:**
+- Modify: `src/smogon_vgc_mcp/formats.py`
+- Modify: `src/smogon_vgc_mcp/fetcher/sheets.py`
+- Create: `tests/test_sheets_champions.py`
+
+- [ ] **Step 1: Write failing sheet extension test**
+
+Create `tests/test_sheets_champions.py`:
+
+```python
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from smogon_vgc_mcp.database.schema import get_connection, init_database
+from smogon_vgc_mcp.fetcher.sheets import ingest_champions_sheet
+from smogon_vgc_mcp.resilience import FetchResult
+
+
+@pytest.fixture
+async def db_path(tmp_path: Path):
+    p = tmp_path / "test.db"
+    await init_database(p)
+    return p
+
+
+MIXED_SHEET_CSV = """Owner,Tournament,Rank,URL
+Alice,Regional A,Top 8,https://pokepast.es/abc123
+Bob,Regional B,Winner,https://x.com/bob/status/42
+Carol,Regional C,Top 4,https://someblog.example/post
+"""
+
+
+async def test_ingest_champions_sheet_routes_by_url_shape(db_path: Path):
+    pokepaste_text = "Koraidon @ Life Orb\nAbility: Orichalcum Pulse\nLevel: 50\nEVs: 32 Atk\nAdamant Nature\n- Flare Blitz\n- Protect\n- Collision Course\n- Dragon Claw"
+
+    with (
+        patch(
+            "smogon_vgc_mcp.fetcher.sheets.fetch_text_resilient",
+            new=AsyncMock(return_value=FetchResult.ok(MIXED_SHEET_CSV)),
+        ),
+        patch(
+            "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+            new=AsyncMock(return_value=FetchResult.ok(pokepaste_text)),
+        ),
+    ):
+        report = await ingest_champions_sheet(db_path=db_path)
+
+    # 3 rows: 1 pokepaste (auto), 2 rejected as tier_not_implemented
+    assert report["auto"] == 1
+    assert report["rejected"] == 2
+    assert report["fetch_failed"] == 0
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```bash
+uv run pytest tests/test_sheets_champions.py -v
+```
+Expected: FAIL (`ingest_champions_sheet` missing).
+
+- [ ] **Step 3: Set champions_ma sheet_gid + implement sheet ingestion**
+
+In `src/smogon_vgc_mcp/formats.py`, update `champions_ma` FormatConfig entry to set:
+
+```python
+        sheet_gid="791705272",
+```
+
+(Leave the rest of the entry as-is.)
+
+Append to `src/smogon_vgc_mcp/fetcher/sheets.py`:
+
+```python
+from pathlib import Path
+
+from smogon_vgc_mcp.fetcher.ingestion.pipeline import ingest_url
+from smogon_vgc_mcp.formats import get_sheet_csv_url
+
+
+async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
+    """Read the Champions Google Sheet tab and ingest each row's URL.
+
+    Returns a counter dict of status -> count.
+    """
+    sheet_url = get_sheet_csv_url("champions_ma")
+    if not sheet_url:
+        return {"auto": 0, "review_pending": 0, "rejected": 0, "fetch_failed": 0, "parse_failed": 0}
+
+    fetched = await fetch_text_resilient(sheet_url, service="sheets")
+    if not fetched.success or not fetched.data:
+        return {"auto": 0, "review_pending": 0, "rejected": 0, "fetch_failed": 1, "parse_failed": 0}
+
+    reader = csv.reader(io.StringIO(fetched.data))
+    rows = list(reader)
+
+    counts: dict[str, int] = {
+        "auto": 0, "review_pending": 0, "rejected": 0,
+        "fetch_failed": 0, "parse_failed": 0,
+    }
+
+    for row in rows[1:]:  # skip header
+        url = next((c for c in row if c.startswith(("http://", "https://"))), "")
+        if not url:
+            continue
+        result = await ingest_url(url, db_path=db_path)
+        counts[result.status] = counts.get(result.status, 0) + 1
+
+    return counts
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+uv run pytest tests/test_sheets_champions.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/formats.py src/smogon_vgc_mcp/fetcher/sheets.py tests/test_sheets_champions.py
+git commit -m "feat(sheets): champions sheet ingestion routing rows through pipeline"
+```
+
+---
+
+## Task 13: Reactive `vgc-ingest <url>` CLI
+
+**Files:**
+- Create: `src/smogon_vgc_mcp/entry/ingest_cli.py`
+- Modify: `pyproject.toml`
+- Create: `tests/test_ingestion_cli.py`
+
+- [ ] **Step 1: Write failing CLI test**
+
+Create `tests/test_ingestion_cli.py`:
+
+```python
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from smogon_vgc_mcp.database.schema import init_database
+from smogon_vgc_mcp.entry.ingest_cli import main_async
+from smogon_vgc_mcp.resilience import FetchResult
+
+
+@pytest.fixture
+async def db_path(tmp_path: Path):
+    p = tmp_path / "test.db"
+    await init_database(p)
+    return p
+
+
+async def test_cli_auto_write_exit_zero(db_path: Path, capsys):
+    pokepaste_text = "Koraidon @ Life Orb\nAbility: Orichalcum Pulse\nLevel: 50\nEVs: 32 Atk\nAdamant Nature\n- Flare Blitz\n- Protect\n- Collision Course\n- Dragon Claw"
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.ok(pokepaste_text)),
+    ):
+        exit_code = await main_async(["https://pokepast.es/abc"], db_path=db_path)
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "auto" in captured.out.lower()
+
+
+async def test_cli_rejected_exit_nonzero(db_path: Path, capsys):
+    exit_code = await main_async(["not-a-url"], db_path=db_path)
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "rejected" in captured.out.lower()
+
+
+async def test_cli_missing_url_exit_usage(db_path: Path, capsys):
+    exit_code = await main_async([], db_path=db_path)
+    assert exit_code == 1
+```
+
+- [ ] **Step 2: Run — expect ImportError**
+
+```bash
+uv run pytest tests/test_ingestion_cli.py -v
+```
+Expected: FAIL.
+
+- [ ] **Step 3: Implement CLI**
+
+Create `src/smogon_vgc_mcp/entry/ingest_cli.py`:
+
+```python
+"""vgc-ingest CLI: ingest a single URL into champions_teams."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+from smogon_vgc_mcp.fetcher.ingestion.pipeline import ingest_url
+
+
+async def main_async(argv: list[str], *, db_path: Path | None = None) -> int:
+    if not argv:
+        print("Usage: vgc-ingest <url>", file=sys.stderr)
+        return 1
+    url = argv[0]
+    result = await ingest_url(url, db_path=db_path)
+    print(f"status: {result.status}")
+    if result.team_row_id is not None:
+        print(f"team_row_id: {result.team_row_id}")
+    if result.confidence is not None:
+        print(f"confidence: {result.confidence:.2f}")
+    if result.reason:
+        print(f"reason: {result.reason}")
+
+    if result.status in ("auto", "review_pending"):
+        return 0
+    if result.status in ("fetch_failed", "parse_failed"):
+        return 3
+    return 2  # rejected
+
+
+def main() -> None:
+    sys.exit(asyncio.run(main_async(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+In `pyproject.toml`, add to `[project.scripts]` (locate the existing block — similar to `smogon-vgc-mcp` or `vgc-build`):
+
+```toml
+vgc-ingest = "smogon_vgc_mcp.entry.ingest_cli:main"
+```
+
+Then regenerate the lock:
+
+```bash
+uv sync
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+uv run pytest tests/test_ingestion_cli.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Run full suite + lint**
+
+```bash
+uv run pytest --ignore=tests/integration -q
+uv run ruff check src/smogon_vgc_mcp/fetcher/ingestion/ src/smogon_vgc_mcp/database/champions_team_queries.py src/smogon_vgc_mcp/entry/ingest_cli.py tests/test_ingestion_*.py tests/test_champions_team_queries.py tests/test_champions_team_schema.py tests/test_sheets_champions.py
+uv run ruff format --check src/smogon_vgc_mcp/fetcher/ingestion/ src/smogon_vgc_mcp/database/champions_team_queries.py src/smogon_vgc_mcp/entry/ingest_cli.py tests/test_ingestion_*.py tests/test_champions_team_queries.py tests/test_champions_team_schema.py tests/test_sheets_champions.py
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/smogon_vgc_mcp/entry/ingest_cli.py pyproject.toml uv.lock tests/test_ingestion_cli.py
+git commit -m "feat(cli): vgc-ingest reactive ingestion for single URL"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage**: Schema (T1), models (T2), validator §all (T3-T6), normalizer (T7), queries + fingerprint (T8), classifier (T9), Tier 1 (T10), pipeline (T11), sheet extension + Champions format config (T12), reactive CLI (T13). Phases 3-6 explicitly deferred.
+- **Placeholders**: none. Every step includes actual code or exact commands.
+- **Type consistency**: `ChampionsTeam`, `ChampionsTeamPokemon`, `ChampionsTeamDraft`, `ValidationReport`, `Tier`, `IngestResult` match across tasks. `write_or_queue_team` / `ingest_url` / `classify_url` / `normalize` / `validate` signatures consistent with test call sites.
+- **Not in this plan (intentional)**: Tier 2 embedded Showdown (next plan), Tier 3 LLM + X/blog adapters (next plan), audit layer + MCP tool (next plan), labeler queue source (next plan), OCR (deferred indefinitely), proactive scheduler (deferred).
+
+---
+
+## Done When
+
+- All 13 tasks' checkboxes complete
+- `uv run pytest --ignore=tests/integration -q` fully green
+- `uv run ruff check` clean on new files
+- `vgc-ingest https://pokepast.es/<real-champions-team>` lands a row in `champions_teams` with `ingestion_status='auto'`
+- `ingest_champions_sheet()` called against the real Champions sheet tab produces a mix of `auto` (pokepaste rows) and `rejected:tier_not_implemented` (X + blog rows), with no crashes
+
+Next plan will pick up at Phase 3 (Tier 2 + Tier 3 + X/blog adapters).

--- a/docs/superpowers/specs/2026-04-22-champions-team-ingestion-design.md
+++ b/docs/superpowers/specs/2026-04-22-champions-team-ingestion-design.md
@@ -1,0 +1,255 @@
+# Champions Team Ingestion Pipeline — Design
+
+**Status**: Approved (2026-04-22)
+**Priority**: Champions format (`champions_ma`) — the format going forward
+
+## Goal
+
+Ingest competitive Champions team sets from three source shapes — pokepaste links, X (Twitter) posts, and blog articles — into new Champions-specific storage tables. Pipeline is hybrid: deterministic parsers + Haiku LLM extractor, gated by confidence. High-confidence extractions land directly in `champions_teams`; low-confidence ones queue into the existing labeler for human review. A deterministic validator runs on every extraction and is re-runnable as a batch audit over stored rows.
+
+## Non-Goals (YAGNI)
+
+- OCR on team screenshots (Tier 4 deferred)
+- Proactive scheduled crawler / watchlist walker (phase 2)
+- X thread / reply aggregation — single-post scope only
+- RSS following of blogs
+- Reg I or other-format ingestion — same classifier, different storage (future)
+
+## Background
+
+- Existing `teams` / `team_pokemon` tables use Gen 9 EV/IV shape (hp_ev/atk_ev/... and IVs). Champions uses **Stat Points**: 66 SP total, ≤32 per stat, everyone at level 50. Storage shape is different enough to warrant parallel tables (same pattern used for `champions_dex_*`).
+- `ArticleSource` Protocol and `AnthropicPrefiller` were added during the labeler workstation (PR #14) and are source-agnostic — they can be extended to service the new ingestion queue with minimal adaptation.
+- The tournament teams Google Sheet already drives `regf` ingestion. A new tab (`gid=791705272`, assumed Champions) contains mixed URL shapes (pokepaste + X + blog) and will seed the pipeline.
+
+## Architecture
+
+```
+  vgc-ingest <url>             sheet puller              (phase 2: X/blog watchlist)
+         |                         |                              |
+         +-------------------------+------------------------------+
+                                   v
+                       URL Shape Classifier
+                                   v
+     +-------------+---------------+--------------+
+     v             v               v              v
+  TIER 1        TIER 2          TIER 3         REJECT
+ pokepaste.es  embedded        prose + LLM    (unknown)
+ conf = 1.0    Showdown block  conf 0.3-0.9
+               conf ~= 0.9
+     |             |               |
+     +-------------+---------------+
+                   v
+        Normalize (aliases, fuzzy move/pokemon names)
+                   v
+        Validate (SP rules + dex + ability + learnset)
+                   v
+          final_confidence >= 0.85 ?
+              |              |
+             YES             NO
+              v              v
+   champions_teams    labeler queue
+   (ingestion_status  (ingestion_status
+    = 'auto')          = 'review_pending')
+```
+
+## Data Model
+
+### New Tables
+
+```sql
+CREATE TABLE champions_teams (
+  id INTEGER PRIMARY KEY,
+  format TEXT NOT NULL DEFAULT 'champions_ma',
+  team_id TEXT NOT NULL,                -- deterministic hash of set fingerprint
+  description TEXT,
+  owner TEXT,
+  source_type TEXT NOT NULL,            -- 'sheet' | 'pokepaste' | 'x' | 'blog'
+  source_url TEXT NOT NULL,
+  ingestion_status TEXT NOT NULL,       -- 'auto' | 'review_pending' | 'labeled'
+                                        -- | 'fetch_failed' | 'parse_failed'
+  confidence_score REAL NOT NULL,
+  review_reasons TEXT,                  -- JSON array of validator reason codes
+  normalizations TEXT,                  -- JSON array of auto-fixes applied
+  ingested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(format, team_id)
+);
+
+CREATE TABLE champions_team_pokemon (
+  id INTEGER PRIMARY KEY,
+  team_id INTEGER NOT NULL REFERENCES champions_teams(id) ON DELETE CASCADE,
+  slot INTEGER NOT NULL,
+  pokemon TEXT NOT NULL,
+  item TEXT,
+  ability TEXT,
+  nature TEXT,
+  tera_type TEXT,
+  level INTEGER DEFAULT 50,
+  sp_hp INTEGER DEFAULT 0, sp_atk INTEGER DEFAULT 0, sp_def INTEGER DEFAULT 0,
+  sp_spa INTEGER DEFAULT 0, sp_spd INTEGER DEFAULT 0, sp_spe INTEGER DEFAULT 0,
+  move1 TEXT, move2 TEXT, move3 TEXT, move4 TEXT,
+  UNIQUE(team_id, slot),
+  CHECK(sp_hp BETWEEN 0 AND 32),
+  CHECK(sp_atk BETWEEN 0 AND 32),
+  CHECK(sp_def BETWEEN 0 AND 32),
+  CHECK(sp_spa BETWEEN 0 AND 32),
+  CHECK(sp_spd BETWEEN 0 AND 32),
+  CHECK(sp_spe BETWEEN 0 AND 32),
+  CHECK(sp_hp + sp_atk + sp_def + sp_spa + sp_spd + sp_spe <= 66),
+  CHECK(slot BETWEEN 1 AND 6)
+);
+
+CREATE INDEX idx_champions_teams_format ON champions_teams(format);
+CREATE INDEX idx_champions_teams_source ON champions_teams(source_type);
+CREATE INDEX idx_champions_teams_status ON champions_teams(ingestion_status);
+CREATE INDEX idx_champions_team_pokemon_pokemon ON champions_team_pokemon(pokemon);
+CREATE INDEX idx_champions_team_pokemon_team_id ON champions_team_pokemon(team_id);
+```
+
+## Components
+
+| Module | Purpose |
+|---|---|
+| `fetcher/ingestion/classifier.py` | URL regex + domain list → `Tier` enum (`POKEPASTE`, `X`, `BLOG`, `UNKNOWN`) |
+| `fetcher/ingestion/tier1_pokepaste.py` | Reuse existing `pokepaste.py`; adapt output to SP fields |
+| `fetcher/ingestion/tier2_showdown_block.py` | Python port of `parseShowdownImport` from `labeler/static/labeler.js`; detect and parse embedded Showdown blocks in free text |
+| `fetcher/ingestion/tier3_llm.py` | Champions-aware Haiku system prompt (SP field names, 32/66 constraints); reuse `AnthropicPrefiller` client |
+| `fetcher/ingestion/x_adapter.py` | Fetch X post text via `publish.twitter.com/oembed` (no auth, public posts only) |
+| `fetcher/ingestion/blog_adapter.py` | Generic blog extraction via `trafilatura` (MIT, no Chromium dep) |
+| `fetcher/ingestion/normalizer.py` | Alias tables (Pokemon, items), Levenshtein ≤2 fuzzy match for moves |
+| `fetcher/ingestion/validator.py` | Pure-function `ValidationReport` generator |
+| `fetcher/ingestion/audit.py` | Batch auditor over stored rows |
+| `fetcher/ingestion/pipeline.py` | Top-level orchestrator: classify → fetch → extract → normalize → validate → write/queue |
+| `database/champions_team_queries.py` | CRUD + write-or-queue routing |
+| `fetcher/sheets.py` (extend) | Branch on URL shape when reading the Champions tab |
+| `labeler/sources.py::ChampionsTeamQueueSource` | New `ArticleSource` surfacing `review_pending` rows |
+| `tools/ingest_team.py` | MCP tool `ingest_team(url)` |
+| `entry/ingest_cli.py` | `vgc-ingest <url>` CLI |
+
+## Validator Specification
+
+### `ValidationReport`
+
+```python
+@dataclass(frozen=True)
+class ValidationReport:
+    passed: bool                   # True iff no hard failures
+    hard_failures: list[str]       # reason codes (see table below)
+    soft_failures: list[str]       # reason codes
+    normalizations: list[str]      # audit log of auto-fixes
+```
+
+### Check Table
+
+| Reason code | Severity | Rule |
+|---|---|---|
+| `sp_over_per_stat` | hard | any `sp_X > 32` |
+| `sp_over_total` | hard | `sum(sp_X) > 66` |
+| `sp_negative` | hard | any `sp_X < 0` |
+| `slot_count` | hard | team has 0 slots or > 6 slots |
+| `duplicate_species` | hard | same base species appears twice (Species Clause) |
+| `pokemon_unknown` | hard | not in `champions_dex_pokemon` after normalization |
+| `ability_illegal` | soft | not in that Pokemon's legal ability set |
+| `move_illegal` | soft | not in that Pokemon's learnset |
+| `item_unknown` | soft | item name not in known item list |
+| `nature_unknown` | soft | not one of 25 natures |
+| `tera_type_unknown` | soft | not one of 18 types (nullable field) |
+| `move_count` | soft | < 1 or > 4 moves per slot |
+| `lossy_roundtrip` | soft | Tier 1/2 only — re-serialized Showdown text differs from source |
+
+### Normalization Pass
+
+Runs before checks, logs each change into `normalizations[]`:
+
+- **Pokemon name**: "urshifu-s" → "Urshifu-Single-Strike" via alias table
+- **Move name**: Levenshtein ≤ 2 against `champions_dex_moves` (e.g., "Close Combatt" → "Close Combat")
+- **Item**: strip trailing " (consumed)", case-fold match against known item list
+- **Nature**: title-case
+- **Tera type**: title-case, nullable
+
+### Confidence Interaction
+
+```
+final_confidence = tier_baseline
+                   - 0.1 * len(soft_failures)
+                   + tier_modifiers
+if hard_failures:
+    final_confidence = 0.0   # forces queue regardless of tier
+```
+
+## Confidence Scoring
+
+| Tier | Baseline | Modifiers |
+|------|----------|-----------|
+| 1 pokepaste | 1.00 | −0.10 partial parse; −0.20 on 4xx |
+| 2 embedded Showdown | 0.90 | +0.05 if all 6 slots complete; −0.20 if < 3 moves/slot avg |
+| 3 LLM prose | 0.50 | +0.10 per fully-populated set; −0.30 if validator rejects |
+
+**Auto-write threshold: `0.85`**. Below → labeler queue with `ingestion_status='review_pending'`.
+
+## Audit Layer
+
+`fetcher/ingestion/audit.py` re-runs the validator over stored rows. Use cases:
+
+- Dex data update invalidates previously valid teams (ability removed, learnset change)
+- Normalizer bug fix — stored `normalizations` no longer line up
+- Validator rule change — new check retroactively applied
+
+Entry points:
+
+- **CLI `vgc-audit-teams`** — walks `champions_teams`, re-validates, emits TSV report (`team_id\tstatus\treasons`), optionally flips `ingestion_status` to `review_pending` on new failures (gated behind `--apply`)
+- **MCP tool `audit_champions_team(team_id)`** — on-demand single-row check
+
+## Data Flow
+
+1. **Reactive**: `vgc-ingest <url>` → classifier → tier handler → normalizer → validator → `champions_teams` (auto) or labeler queue
+2. **Sheet seed**: `sheets.py` reads Champions tab (`gid=791705272`), classifies each row's URL, routes through the same pipeline. Pokepaste rows typically auto-land; X/blog rows flow through Tier 2/3
+3. **Proactive watchlist (phase 2)**: scheduled job walks known X handles + blog RSS — deferred
+
+## Error Handling
+
+- **Classifier REJECT** (URL shape unknown) → no row written; reactive CLI returns a non-zero exit with reason; sheet puller logs and moves on. No labeler queue entry.
+- **Fetch failures** (4xx/5xx, timeout) → `ingestion_status='fetch_failed'`, retried on next sheet pull
+- **Parse failures** (unrecognized format, malformed JSON from LLM) → `ingestion_status='parse_failed'` with human-readable reason; surfaces in labeler queue
+- **LLM rate limit / 5xx** → exponential backoff with jitter; fall through to queue with reason `llm_unavailable`
+- **Hard validator failures** → always queue (`review_pending`), never auto-write
+- **Duplicate team_id** (same source_url + same set fingerprint hash) → skip, log at debug
+
+## Testing
+
+- **Unit**: per-tier fixture tests (canned pokepaste raw, canned Showdown block, canned prose article)
+- **Property**: SP validator boundaries (32, 33, 66, 67, 0, −1)
+- **Routing**: classifier mapping test — 10 canned URLs → expected tier
+- **Integration**: sheet row → pipeline → row present in `champions_teams` with expected shape
+- **Audit regression**: mutate a stored row to violate a rule, run audit, assert flagged
+- **Round-trip**: Tier 1/2 golden set — parse → re-serialize → byte-compare
+- **Eval loop**: Champions queue flows into the existing labeler correction-rate dashboard (no new infra needed)
+
+## Integration with Labeler (PR #14)
+
+Once merged, PR #14's labeler gains a new `ArticleSource`:
+
+```python
+class ChampionsTeamQueueSource:
+    source_name = "champions_team_queue"
+    # lists champions_teams rows WHERE ingestion_status = 'review_pending'
+    # get_article() synthesizes a read-only detail view with extraction context
+```
+
+The existing prefill + correction-rate infra Just Works on this source.
+
+## Open Questions / Assumptions to Verify
+
+- **Sheet tab identity**: Assumed `gid=791705272` is the Champions tab. If it's actually Reg I, either (a) add a second tab for Champions, or (b) route by row `format` column if the sheet has one. Verification on first read is cheap.
+- **X oEmbed sufficiency**: Public oEmbed returns tweet text + basic HTML. If posts routinely embed sets as images (screenshots), Tier 3 cannot recover them and OCR becomes necessary — reassess after first 50 X ingestions.
+- **Set fingerprint hashing**: Use `sha256(sorted(tuple(pokemon_name, moves_sorted, sp_tuple) for slot in slots))` for dedup — documented in `champions_team_queries.py`.
+
+## Delivery Phases
+
+1. **Schema + validator + normalizer** (foundational, no external I/O)
+2. **Tier 1 + sheet extension** (reuse existing pokepaste infra; ships usable ingestion for majority of sheet rows)
+3. **Tier 2 (embedded Showdown)** (pure parsing, reuses normalization/validator)
+4. **Tier 3 (LLM) + X adapter + blog adapter** (adds network + model cost)
+5. **Audit layer + CLI + MCP tool**
+6. **Labeler queue source integration**
+
+Each phase ships independently with tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ labeler = [
 [project.scripts]
 smogon-vgc-mcp = "smogon_vgc_mcp.entry.stdio:main"
 vgc-build = "vgc_agent.cli:main"
+vgc-ingest = "smogon_vgc_mcp.entry.ingest_cli:main"
 vgc-label = "smogon_vgc_mcp.labeler.cli:main"
 
 [dependency-groups]

--- a/src/smogon_vgc_mcp/database/champions_team_queries.py
+++ b/src/smogon_vgc_mcp/database/champions_team_queries.py
@@ -27,6 +27,7 @@ def compute_team_fingerprint(pokemon: list[ChampionsTeamPokemon]) -> str:
         moves = tuple(sorted(m for m in (p.move1, p.move2, p.move3, p.move4) if m))
         canonical.append(
             (
+                p.slot,
                 p.pokemon.casefold(),
                 (p.ability or "").casefold(),
                 (p.item or "").casefold(),

--- a/src/smogon_vgc_mcp/database/champions_team_queries.py
+++ b/src/smogon_vgc_mcp/database/champions_team_queries.py
@@ -57,123 +57,132 @@ async def write_or_queue_team(db: aiosqlite.Connection, team: ChampionsTeam) -> 
     prior row first.
 
     Commits internally; the caller should not wrap this in its own
-    transaction expecting to rollback. Permanently mutates
-    ``db.row_factory`` on the caller's connection to ``aiosqlite.Row``;
-    any subsequent query on the same connection will receive ``Row``
-    objects instead of plain tuples.
+    transaction expecting to rollback. ``db.row_factory`` is temporarily
+    switched to ``aiosqlite.Row`` for the dedup lookup and restored
+    before return, so the caller's connection state is preserved for
+    any subsequent queries that expect tuples.
     """
+    prior_factory = db.row_factory
     db.row_factory = aiosqlite.Row
+    try:
+        existing = await db.execute_fetchall(
+            "SELECT id FROM champions_teams WHERE format = ? AND team_id = ?",
+            (team.format, team.team_id),
+        )
+        if existing:
+            return int(existing[0]["id"])
 
-    existing = await db.execute_fetchall(
-        "SELECT id FROM champions_teams WHERE format = ? AND team_id = ?",
-        (team.format, team.team_id),
-    )
-    if existing:
-        return int(existing[0]["id"])
-
-    cursor = await db.execute(
-        """
-        INSERT INTO champions_teams(
-            format, team_id, description, owner, source_type, source_url,
-            ingestion_status, confidence_score, review_reasons, normalizations
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-        (
-            team.format,
-            team.team_id,
-            team.description,
-            team.owner,
-            team.source_type,
-            team.source_url,
-            team.ingestion_status,
-            team.confidence_score,
-            json.dumps(team.review_reasons) if team.review_reasons else None,
-            json.dumps(team.normalizations) if team.normalizations else None,
-        ),
-    )
-    team_row_id = cursor.lastrowid
-    if team_row_id is None:
-        raise RuntimeError("INSERT into champions_teams returned no lastrowid")
-
-    for poke in team.pokemon:
-        await db.execute(
+        cursor = await db.execute(
             """
-            INSERT INTO champions_team_pokemon(
-                team_id, slot, pokemon, item, ability, nature, tera_type, level,
-                sp_hp, sp_atk, sp_def, sp_spa, sp_spd, sp_spe,
-                move1, move2, move3, move4
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO champions_teams(
+                format, team_id, description, owner, source_type, source_url,
+                ingestion_status, confidence_score, review_reasons, normalizations
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                team_row_id,
-                poke.slot,
-                poke.pokemon,
-                poke.item,
-                poke.ability,
-                poke.nature,
-                poke.tera_type,
-                poke.level,
-                poke.sp_hp,
-                poke.sp_atk,
-                poke.sp_def,
-                poke.sp_spa,
-                poke.sp_spd,
-                poke.sp_spe,
-                poke.move1,
-                poke.move2,
-                poke.move3,
-                poke.move4,
+                team.format,
+                team.team_id,
+                team.description,
+                team.owner,
+                team.source_type,
+                team.source_url,
+                team.ingestion_status,
+                team.confidence_score,
+                json.dumps(team.review_reasons) if team.review_reasons else None,
+                json.dumps(team.normalizations) if team.normalizations else None,
             ),
         )
+        team_row_id = cursor.lastrowid
+        if team_row_id is None:
+            raise RuntimeError("INSERT into champions_teams returned no lastrowid")
 
-    await db.commit()
-    return int(team_row_id)
+        for poke in team.pokemon:
+            await db.execute(
+                """
+                INSERT INTO champions_team_pokemon(
+                    team_id, slot, pokemon, item, ability, nature, tera_type, level,
+                    sp_hp, sp_atk, sp_def, sp_spa, sp_spd, sp_spe,
+                    move1, move2, move3, move4
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    team_row_id,
+                    poke.slot,
+                    poke.pokemon,
+                    poke.item,
+                    poke.ability,
+                    poke.nature,
+                    poke.tera_type,
+                    poke.level,
+                    poke.sp_hp,
+                    poke.sp_atk,
+                    poke.sp_def,
+                    poke.sp_spa,
+                    poke.sp_spd,
+                    poke.sp_spe,
+                    poke.move1,
+                    poke.move2,
+                    poke.move3,
+                    poke.move4,
+                ),
+            )
+
+        await db.commit()
+        return int(team_row_id)
+    finally:
+        db.row_factory = prior_factory
 
 
 async def get_champions_team(db: aiosqlite.Connection, row_id: int) -> ChampionsTeam | None:
+    prior_factory = db.row_factory
     db.row_factory = aiosqlite.Row
-    team_row = await db.execute_fetchall("SELECT * FROM champions_teams WHERE id = ?", (row_id,))
-    if not team_row:
-        return None
-    t = team_row[0]
-
-    poke_rows = await db.execute_fetchall(
-        "SELECT * FROM champions_team_pokemon WHERE team_id = ? ORDER BY slot",
-        (row_id,),
-    )
-    pokemon = [
-        ChampionsTeamPokemon(
-            slot=p["slot"],
-            pokemon=p["pokemon"],
-            item=p["item"],
-            ability=p["ability"],
-            nature=p["nature"],
-            tera_type=p["tera_type"],
-            level=p["level"],
-            sp_hp=p["sp_hp"],
-            sp_atk=p["sp_atk"],
-            sp_def=p["sp_def"],
-            sp_spa=p["sp_spa"],
-            sp_spd=p["sp_spd"],
-            sp_spe=p["sp_spe"],
-            move1=p["move1"],
-            move2=p["move2"],
-            move3=p["move3"],
-            move4=p["move4"],
+    try:
+        team_row = await db.execute_fetchall(
+            "SELECT * FROM champions_teams WHERE id = ?", (row_id,)
         )
-        for p in poke_rows
-    ]
+        if not team_row:
+            return None
+        t = team_row[0]
 
-    return ChampionsTeam(
-        team_id=t["team_id"],
-        format=t["format"],
-        description=t["description"],
-        owner=t["owner"],
-        source_type=t["source_type"],
-        source_url=t["source_url"],
-        ingestion_status=t["ingestion_status"],
-        confidence_score=t["confidence_score"],
-        review_reasons=json.loads(t["review_reasons"]) if t["review_reasons"] else None,
-        normalizations=json.loads(t["normalizations"]) if t["normalizations"] else None,
-        pokemon=pokemon,
-    )
+        poke_rows = await db.execute_fetchall(
+            "SELECT * FROM champions_team_pokemon WHERE team_id = ? ORDER BY slot",
+            (row_id,),
+        )
+        pokemon = [
+            ChampionsTeamPokemon(
+                slot=p["slot"],
+                pokemon=p["pokemon"],
+                item=p["item"],
+                ability=p["ability"],
+                nature=p["nature"],
+                tera_type=p["tera_type"],
+                level=p["level"],
+                sp_hp=p["sp_hp"],
+                sp_atk=p["sp_atk"],
+                sp_def=p["sp_def"],
+                sp_spa=p["sp_spa"],
+                sp_spd=p["sp_spd"],
+                sp_spe=p["sp_spe"],
+                move1=p["move1"],
+                move2=p["move2"],
+                move3=p["move3"],
+                move4=p["move4"],
+            )
+            for p in poke_rows
+        ]
+
+        return ChampionsTeam(
+            team_id=t["team_id"],
+            format=t["format"],
+            description=t["description"],
+            owner=t["owner"],
+            source_type=t["source_type"],
+            source_url=t["source_url"],
+            ingestion_status=t["ingestion_status"],
+            confidence_score=t["confidence_score"],
+            review_reasons=json.loads(t["review_reasons"]) if t["review_reasons"] else None,
+            normalizations=json.loads(t["normalizations"]) if t["normalizations"] else None,
+            pokemon=pokemon,
+        )
+    finally:
+        db.row_factory = prior_factory

--- a/src/smogon_vgc_mcp/database/champions_team_queries.py
+++ b/src/smogon_vgc_mcp/database/champions_team_queries.py
@@ -13,8 +13,10 @@ from smogon_vgc_mcp.database.models import ChampionsTeam, ChampionsTeamPokemon
 def compute_team_fingerprint(pokemon: list[ChampionsTeamPokemon]) -> str:
     """Stable SHA256 of the team's structural content.
 
-    Move order within a set is normalized (sorted) so a team that
-    reorders moves doesn't produce a different fingerprint.
+    Pokemon are sorted by ``(slot, pokemon)`` and moves within a set
+    are sorted before hashing — reordering moves within a slot does
+    not change the fingerprint, but reassigning a species to a
+    different slot does.
     """
     canonical = []
     for p in sorted(pokemon, key=lambda x: (x.slot, x.pokemon.casefold())):
@@ -72,6 +74,8 @@ async def write_or_queue_team(db: aiosqlite.Connection, team: ChampionsTeam) -> 
         ),
     )
     team_row_id = cursor.lastrowid
+    if team_row_id is None:
+        raise RuntimeError("INSERT into champions_teams returned no lastrowid")
 
     for poke in team.pokemon:
         await db.execute(

--- a/src/smogon_vgc_mcp/database/champions_team_queries.py
+++ b/src/smogon_vgc_mcp/database/champions_team_queries.py
@@ -11,7 +11,11 @@ from smogon_vgc_mcp.database.models import ChampionsTeam, ChampionsTeamPokemon
 
 
 def compute_team_fingerprint(pokemon: list[ChampionsTeamPokemon]) -> str:
-    """Stable SHA256 of the team's structural content.
+    """Stable 16-hex-char prefix of SHA256 over the team's structure.
+
+    The full SHA256 digest is truncated to its first 16 hex characters
+    (64 bits) — collision probability is negligible at champion-team
+    volumes but note the hash is not full-strength.
 
     Pokemon are sorted by ``(slot, pokemon)`` and moves within a set
     are sorted before hashing — reordering moves within a slot does
@@ -43,7 +47,12 @@ def compute_team_fingerprint(pokemon: list[ChampionsTeamPokemon]) -> str:
 
 
 async def write_or_queue_team(db: aiosqlite.Connection, team: ChampionsTeam) -> int:
-    """Insert the team. Returns the row id. Duplicate (format, team_id) returns existing id."""
+    """Insert the team. Returns the row id. Duplicate (format, team_id) returns existing id.
+
+    Commits internally; the caller should not wrap this in its own
+    transaction expecting to rollback. Also sets ``db.row_factory`` to
+    ``aiosqlite.Row`` on the connection.
+    """
     db.row_factory = aiosqlite.Row
 
     existing = await db.execute_fetchall(

--- a/src/smogon_vgc_mcp/database/champions_team_queries.py
+++ b/src/smogon_vgc_mcp/database/champions_team_queries.py
@@ -43,7 +43,7 @@ def compute_team_fingerprint(pokemon: list[ChampionsTeamPokemon]) -> str:
                 moves,
             )
         )
-    digest = hashlib.sha256(json.dumps(canonical, sort_keys=True).encode()).hexdigest()
+    digest = hashlib.sha256(json.dumps(canonical).encode()).hexdigest()
     return digest[:16]
 
 
@@ -57,8 +57,10 @@ async def write_or_queue_team(db: aiosqlite.Connection, team: ChampionsTeam) -> 
     prior row first.
 
     Commits internally; the caller should not wrap this in its own
-    transaction expecting to rollback. Also sets ``db.row_factory`` to
-    ``aiosqlite.Row`` on the connection.
+    transaction expecting to rollback. Permanently mutates
+    ``db.row_factory`` on the caller's connection to ``aiosqlite.Row``;
+    any subsequent query on the same connection will receive ``Row``
+    objects instead of plain tuples.
     """
     db.row_factory = aiosqlite.Row
 

--- a/src/smogon_vgc_mcp/database/champions_team_queries.py
+++ b/src/smogon_vgc_mcp/database/champions_team_queries.py
@@ -50,6 +50,12 @@ def compute_team_fingerprint(pokemon: list[ChampionsTeamPokemon]) -> str:
 async def write_or_queue_team(db: aiosqlite.Connection, team: ChampionsTeam) -> int:
     """Insert the team. Returns the row id. Duplicate (format, team_id) returns existing id.
 
+    Dedup is by ``(format, team_id)`` — on collision the *existing* row
+    is returned untouched; the new ``team`` payload (including its
+    ``source_url``, ``review_reasons``, and Pokemon rows) is discarded.
+    Callers that need update-on-conflict semantics must delete the
+    prior row first.
+
     Commits internally; the caller should not wrap this in its own
     transaction expecting to rollback. Also sets ``db.row_factory`` to
     ``aiosqlite.Row`` on the connection.

--- a/src/smogon_vgc_mcp/database/champions_team_queries.py
+++ b/src/smogon_vgc_mcp/database/champions_team_queries.py
@@ -1,0 +1,157 @@
+"""CRUD + routing for Champions teams."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import aiosqlite
+
+from smogon_vgc_mcp.database.models import ChampionsTeam, ChampionsTeamPokemon
+
+
+def compute_team_fingerprint(pokemon: list[ChampionsTeamPokemon]) -> str:
+    """Stable SHA256 of the team's structural content.
+
+    Move order within a set is normalized (sorted) so a team that
+    reorders moves doesn't produce a different fingerprint.
+    """
+    canonical = []
+    for p in sorted(pokemon, key=lambda x: (x.slot, x.pokemon.casefold())):
+        moves = tuple(sorted(m for m in (p.move1, p.move2, p.move3, p.move4) if m))
+        canonical.append(
+            (
+                p.pokemon.casefold(),
+                (p.ability or "").casefold(),
+                (p.item or "").casefold(),
+                (p.nature or "").casefold(),
+                (p.tera_type or "").casefold(),
+                p.level,
+                p.sp_hp,
+                p.sp_atk,
+                p.sp_def,
+                p.sp_spa,
+                p.sp_spd,
+                p.sp_spe,
+                moves,
+            )
+        )
+    digest = hashlib.sha256(json.dumps(canonical, sort_keys=True).encode()).hexdigest()
+    return digest[:16]
+
+
+async def write_or_queue_team(db: aiosqlite.Connection, team: ChampionsTeam) -> int:
+    """Insert the team. Returns the row id. Duplicate (format, team_id) returns existing id."""
+    db.row_factory = aiosqlite.Row
+
+    existing = await db.execute_fetchall(
+        "SELECT id FROM champions_teams WHERE format = ? AND team_id = ?",
+        (team.format, team.team_id),
+    )
+    if existing:
+        return int(existing[0]["id"])
+
+    cursor = await db.execute(
+        """
+        INSERT INTO champions_teams(
+            format, team_id, description, owner, source_type, source_url,
+            ingestion_status, confidence_score, review_reasons, normalizations
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            team.format,
+            team.team_id,
+            team.description,
+            team.owner,
+            team.source_type,
+            team.source_url,
+            team.ingestion_status,
+            team.confidence_score,
+            json.dumps(team.review_reasons) if team.review_reasons else None,
+            json.dumps(team.normalizations) if team.normalizations else None,
+        ),
+    )
+    team_row_id = cursor.lastrowid
+
+    for poke in team.pokemon:
+        await db.execute(
+            """
+            INSERT INTO champions_team_pokemon(
+                team_id, slot, pokemon, item, ability, nature, tera_type, level,
+                sp_hp, sp_atk, sp_def, sp_spa, sp_spd, sp_spe,
+                move1, move2, move3, move4
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                team_row_id,
+                poke.slot,
+                poke.pokemon,
+                poke.item,
+                poke.ability,
+                poke.nature,
+                poke.tera_type,
+                poke.level,
+                poke.sp_hp,
+                poke.sp_atk,
+                poke.sp_def,
+                poke.sp_spa,
+                poke.sp_spd,
+                poke.sp_spe,
+                poke.move1,
+                poke.move2,
+                poke.move3,
+                poke.move4,
+            ),
+        )
+
+    await db.commit()
+    return int(team_row_id)
+
+
+async def get_champions_team(db: aiosqlite.Connection, row_id: int) -> ChampionsTeam | None:
+    db.row_factory = aiosqlite.Row
+    team_row = await db.execute_fetchall("SELECT * FROM champions_teams WHERE id = ?", (row_id,))
+    if not team_row:
+        return None
+    t = team_row[0]
+
+    poke_rows = await db.execute_fetchall(
+        "SELECT * FROM champions_team_pokemon WHERE team_id = ? ORDER BY slot",
+        (row_id,),
+    )
+    pokemon = [
+        ChampionsTeamPokemon(
+            slot=p["slot"],
+            pokemon=p["pokemon"],
+            item=p["item"],
+            ability=p["ability"],
+            nature=p["nature"],
+            tera_type=p["tera_type"],
+            level=p["level"],
+            sp_hp=p["sp_hp"],
+            sp_atk=p["sp_atk"],
+            sp_def=p["sp_def"],
+            sp_spa=p["sp_spa"],
+            sp_spd=p["sp_spd"],
+            sp_spe=p["sp_spe"],
+            move1=p["move1"],
+            move2=p["move2"],
+            move3=p["move3"],
+            move4=p["move4"],
+        )
+        for p in poke_rows
+    ]
+
+    return ChampionsTeam(
+        team_id=t["team_id"],
+        format=t["format"],
+        description=t["description"],
+        owner=t["owner"],
+        source_type=t["source_type"],
+        source_url=t["source_url"],
+        ingestion_status=t["ingestion_status"],
+        confidence_score=t["confidence_score"],
+        review_reasons=json.loads(t["review_reasons"]) if t["review_reasons"] else None,
+        normalizations=json.loads(t["normalizations"]) if t["normalizations"] else None,
+        pokemon=pokemon,
+    )

--- a/src/smogon_vgc_mcp/database/models.py
+++ b/src/smogon_vgc_mcp/database/models.py
@@ -288,3 +288,61 @@ class ChampionsUsageSnapshot:
     elo_cutoff: str
     source: str = "pikalytics"
     fetched_at: str | None = None
+
+
+# =============================================================================
+# Champions team ingestion data models
+# =============================================================================
+
+
+@dataclass
+class ChampionsTeamPokemon:
+    """A Pokemon on a Champions team (Stat Points, not EVs/IVs)."""
+
+    slot: int
+    pokemon: str
+    item: str | None = None
+    ability: str | None = None
+    nature: str | None = None
+    tera_type: str | None = None
+    level: int = 50
+    sp_hp: int = 0
+    sp_atk: int = 0
+    sp_def: int = 0
+    sp_spa: int = 0
+    sp_spd: int = 0
+    sp_spe: int = 0
+    move1: str | None = None
+    move2: str | None = None
+    move3: str | None = None
+    move4: str | None = None
+
+
+@dataclass
+class ChampionsTeam:
+    """A Champions team as stored in champions_teams."""
+
+    team_id: str
+    source_type: str              # 'sheet' | 'pokepaste' | 'x' | 'blog'
+    source_url: str
+    # 'auto' | 'review_pending' | 'labeled' | 'fetch_failed' | 'parse_failed'
+    ingestion_status: str
+    confidence_score: float
+    format: str = "champions_ma"
+    description: str | None = None
+    owner: str | None = None
+    review_reasons: list[str] | None = None
+    normalizations: list[str] | None = None
+    pokemon: list[ChampionsTeamPokemon] = field(default_factory=list)
+
+
+@dataclass
+class ChampionsTeamDraft:
+    """In-flight team from an extractor before validation/write."""
+
+    source_type: str
+    source_url: str
+    tier_baseline_confidence: float
+    description: str | None = None
+    owner: str | None = None
+    pokemon: list[ChampionsTeamPokemon] = field(default_factory=list)

--- a/src/smogon_vgc_mcp/database/models.py
+++ b/src/smogon_vgc_mcp/database/models.py
@@ -4,9 +4,10 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 ChampionsSourceType = Literal["sheet", "pokepaste", "x", "blog"]
-ChampionsIngestionStatus = Literal[
-    "auto", "review_pending", "labeled", "fetch_failed", "parse_failed"
-]
+# Only statuses actually persisted to champions_teams.ingestion_status.
+# Transient pipeline outcomes (fetch_failed / parse_failed / db_error /
+# rejected) are represented on IngestResult, not on ChampionsTeam.
+ChampionsIngestionStatus = Literal["auto", "review_pending", "labeled"]
 
 
 @dataclass

--- a/src/smogon_vgc_mcp/database/models.py
+++ b/src/smogon_vgc_mcp/database/models.py
@@ -7,6 +7,10 @@ ChampionsSourceType = Literal["sheet", "pokepaste", "x", "blog"]
 # Only statuses actually persisted to champions_teams.ingestion_status.
 # Transient pipeline outcomes (fetch_failed / parse_failed / db_error /
 # rejected) are represented on IngestResult, not on ChampionsTeam.
+# "labeled" is reserved for a post-ingestion human-review workflow
+# (not the ingest pipeline itself — the pipeline only writes "auto" or
+# "review_pending"); it marks teams whose review_reasons have been
+# manually triaged.
 ChampionsIngestionStatus = Literal["auto", "review_pending", "labeled"]
 
 

--- a/src/smogon_vgc_mcp/database/models.py
+++ b/src/smogon_vgc_mcp/database/models.py
@@ -1,6 +1,12 @@
 """Data models for Smogon VGC stats."""
 
 from dataclasses import dataclass, field
+from typing import Literal
+
+ChampionsSourceType = Literal["sheet", "pokepaste", "x", "blog"]
+ChampionsIngestionStatus = Literal[
+    "auto", "review_pending", "labeled", "fetch_failed", "parse_failed"
+]
 
 
 @dataclass
@@ -323,10 +329,9 @@ class ChampionsTeam:
     """A Champions team as stored in champions_teams."""
 
     team_id: str
-    source_type: str              # 'sheet' | 'pokepaste' | 'x' | 'blog'
+    source_type: ChampionsSourceType
     source_url: str
-    # 'auto' | 'review_pending' | 'labeled' | 'fetch_failed' | 'parse_failed'
-    ingestion_status: str
+    ingestion_status: ChampionsIngestionStatus
     confidence_score: float
     format: str = "champions_ma"
     description: str | None = None
@@ -338,9 +343,13 @@ class ChampionsTeam:
 
 @dataclass
 class ChampionsTeamDraft:
-    """In-flight team from an extractor before validation/write."""
+    """In-flight team from an extractor before validation/write.
 
-    source_type: str
+    Missing ``team_id``, ``ingestion_status``, and ``confidence_score`` —
+    the pipeline assigns these after validation, not extractors.
+    """
+
+    source_type: ChampionsSourceType
     source_url: str
     tier_baseline_confidence: float
     description: str | None = None

--- a/src/smogon_vgc_mcp/database/schema.py
+++ b/src/smogon_vgc_mcp/database/schema.py
@@ -404,7 +404,7 @@ CREATE INDEX IF NOT EXISTS idx_champ_pokemon_usage_snap
 # =============================================================================
 # Four additive tables. All rows are per-WordPress-post, per-stage state is
 # tracked via *_status columns so the ingest pipeline is idempotent and
-# resumable. See docs/nugget-bridge.md (PR3) for the pipeline diagram.
+# resumable.
 
 NUGGET_BRIDGE_SCHEMA = """
 -- Raw WordPress post payload + per-stage pipeline state

--- a/src/smogon_vgc_mcp/database/schema.py
+++ b/src/smogon_vgc_mcp/database/schema.py
@@ -554,6 +554,72 @@ async def migrate_add_nugget_bridge_tables(db: aiosqlite.Connection) -> None:
     await db.commit()
 
 
+# =============================================================================
+# Champions team ingestion tables
+# =============================================================================
+
+CHAMPIONS_TEAMS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS champions_teams (
+    id INTEGER PRIMARY KEY,
+    format TEXT NOT NULL DEFAULT 'champions_ma',
+    team_id TEXT NOT NULL,
+    description TEXT,
+    owner TEXT,
+    source_type TEXT NOT NULL,
+    source_url TEXT NOT NULL,
+    ingestion_status TEXT NOT NULL,
+    confidence_score REAL NOT NULL,
+    review_reasons TEXT,
+    normalizations TEXT,
+    ingested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(format, team_id)
+);
+
+CREATE TABLE IF NOT EXISTS champions_team_pokemon (
+    id INTEGER PRIMARY KEY,
+    team_id INTEGER NOT NULL REFERENCES champions_teams(id) ON DELETE CASCADE,
+    slot INTEGER NOT NULL,
+    pokemon TEXT NOT NULL,
+    item TEXT,
+    ability TEXT,
+    nature TEXT,
+    tera_type TEXT,
+    level INTEGER DEFAULT 50,
+    sp_hp INTEGER DEFAULT 0,
+    sp_atk INTEGER DEFAULT 0,
+    sp_def INTEGER DEFAULT 0,
+    sp_spa INTEGER DEFAULT 0,
+    sp_spd INTEGER DEFAULT 0,
+    sp_spe INTEGER DEFAULT 0,
+    move1 TEXT,
+    move2 TEXT,
+    move3 TEXT,
+    move4 TEXT,
+    UNIQUE(team_id, slot),
+    CHECK(sp_hp BETWEEN 0 AND 32),
+    CHECK(sp_atk BETWEEN 0 AND 32),
+    CHECK(sp_def BETWEEN 0 AND 32),
+    CHECK(sp_spa BETWEEN 0 AND 32),
+    CHECK(sp_spd BETWEEN 0 AND 32),
+    CHECK(sp_spe BETWEEN 0 AND 32),
+    CHECK(sp_hp + sp_atk + sp_def + sp_spa + sp_spd + sp_spe <= 66),
+    CHECK(slot BETWEEN 1 AND 6)
+);
+
+CREATE INDEX IF NOT EXISTS idx_champions_teams_format ON champions_teams(format);
+CREATE INDEX IF NOT EXISTS idx_champions_teams_source ON champions_teams(source_type);
+CREATE INDEX IF NOT EXISTS idx_champions_teams_status ON champions_teams(ingestion_status);
+CREATE INDEX IF NOT EXISTS idx_champions_team_pokemon_pokemon ON champions_team_pokemon(pokemon);
+CREATE INDEX IF NOT EXISTS idx_champions_team_pokemon_team_id ON champions_team_pokemon(team_id);
+"""
+
+
+async def migrate_add_champions_teams_tables(db: aiosqlite.Connection) -> None:
+    """Create champions_teams + champions_team_pokemon. Safe on every startup."""
+    await db.executescript(CHAMPIONS_TEAMS_SCHEMA)
+    await db.commit()
+
+
 async def init_database(db_path: Path | None = None) -> None:
     """Initialize the database with schema and run migrations."""
     if db_path is None:
@@ -569,6 +635,7 @@ async def init_database(db_path: Path | None = None) -> None:
         await migrate_add_format_column(db)
         await migrate_add_nugget_bridge_tables(db)
         await migrate_add_labeler_tables(db)
+        await migrate_add_champions_teams_tables(db)
         await db.commit()
 
 

--- a/src/smogon_vgc_mcp/entry/ingest_cli.py
+++ b/src/smogon_vgc_mcp/entry/ingest_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import traceback
 from pathlib import Path
 
 from smogon_vgc_mcp.fetcher.ingestion.pipeline import ingest_url
@@ -35,6 +36,7 @@ def main() -> None:
         sys.exit(asyncio.run(main_async(sys.argv[1:])))
     except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
         sys.exit(3)
 
 

--- a/src/smogon_vgc_mcp/entry/ingest_cli.py
+++ b/src/smogon_vgc_mcp/entry/ingest_cli.py
@@ -1,0 +1,38 @@
+"""vgc-ingest CLI: ingest a single URL into champions_teams."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+from smogon_vgc_mcp.fetcher.ingestion.pipeline import ingest_url
+
+
+async def main_async(argv: list[str], *, db_path: Path | None = None) -> int:
+    if not argv:
+        print("Usage: vgc-ingest <url>", file=sys.stderr)
+        return 1
+    url = argv[0]
+    result = await ingest_url(url, db_path=db_path)
+    print(f"status: {result.status}")
+    if result.team_row_id is not None:
+        print(f"team_row_id: {result.team_row_id}")
+    if result.confidence is not None:
+        print(f"confidence: {result.confidence:.2f}")
+    if result.reason:
+        print(f"reason: {result.reason}")
+
+    if result.status in ("auto", "review_pending"):
+        return 0
+    if result.status in ("fetch_failed", "parse_failed"):
+        return 3
+    return 2  # rejected
+
+
+def main() -> None:
+    sys.exit(asyncio.run(main_async(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/smogon_vgc_mcp/entry/ingest_cli.py
+++ b/src/smogon_vgc_mcp/entry/ingest_cli.py
@@ -24,10 +24,20 @@ async def main_async(argv: list[str], *, db_path: Path | None = None) -> int:
     if result.reason:
         print(f"reason: {result.reason}")
 
+    # Exit code mapping (for scripting / CI):
+    #   0  — persisted (auto or review_pending)
+    #   2  — rejected (URL unsupported or tier not implemented)
+    #   3  — fetch_failed (network / HTTP error)
+    #   4  — parse_failed (non-parseable content)
+    #   5  — db_error (validated team couldn't be persisted)
     if result.status in ("auto", "review_pending"):
         return 0
-    if result.status in ("fetch_failed", "parse_failed"):
+    if result.status == "fetch_failed":
         return 3
+    if result.status == "parse_failed":
+        return 4
+    if result.status == "db_error":
+        return 5
     return 2  # rejected
 
 

--- a/src/smogon_vgc_mcp/entry/ingest_cli.py
+++ b/src/smogon_vgc_mcp/entry/ingest_cli.py
@@ -31,7 +31,11 @@ async def main_async(argv: list[str], *, db_path: Path | None = None) -> int:
 
 
 def main() -> None:
-    sys.exit(asyncio.run(main_async(sys.argv[1:])))
+    try:
+        sys.exit(asyncio.run(main_async(sys.argv[1:])))
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(3)
 
 
 if __name__ == "__main__":

--- a/src/smogon_vgc_mcp/fetcher/ingestion/classifier.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/classifier.py
@@ -1,0 +1,45 @@
+"""URL shape classifier for the ingestion pipeline."""
+
+from __future__ import annotations
+
+from enum import Enum
+from urllib.parse import urlparse
+
+
+class Tier(Enum):
+    POKEPASTE = "pokepaste"
+    X = "x"
+    BLOG = "blog"
+    UNKNOWN = "unknown"
+
+
+_POKEPASTE_HOSTS = frozenset({"pokepast.es", "www.pokepast.es"})
+_X_HOSTS = frozenset(
+    {
+        "twitter.com",
+        "www.twitter.com",
+        "mobile.twitter.com",
+        "x.com",
+        "www.x.com",
+    }
+)
+
+
+def classify_url(url: str) -> Tier:
+    """Return the Tier enum for a raw URL string."""
+    if not url:
+        return Tier.UNKNOWN
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return Tier.UNKNOWN
+    if parsed.scheme not in ("http", "https"):
+        return Tier.UNKNOWN
+    host = (parsed.netloc or "").casefold()
+    if host in _POKEPASTE_HOSTS:
+        return Tier.POKEPASTE
+    if host in _X_HOSTS:
+        return Tier.X
+    if host:  # any other http(s) host counts as a generic blog URL
+        return Tier.BLOG
+    return Tier.UNKNOWN

--- a/src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py
@@ -45,12 +45,20 @@ def _levenshtein(a: str, b: str) -> int:
 
 
 def _closest_move(name: str, known: set[str]) -> str | None:
-    """Return the closest known move within distance 2, else None."""
+    """Return the closest known move within distance 2, else None.
+
+    Ties at the same distance are broken by choosing the
+    lexicographically smallest name, so the result is deterministic
+    regardless of ``known`` iteration order.
+    """
     best: tuple[int, str] | None = None
     for known_name in known:
         d = _levenshtein(name.casefold(), known_name.casefold())
-        if d <= 2 and (best is None or d < best[0]):
-            best = (d, known_name)
+        if d > 2:
+            continue
+        candidate = (d, known_name)
+        if best is None or candidate < best:
+            best = candidate
     return best[1] if best else None
 
 

--- a/src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py
@@ -1,0 +1,108 @@
+"""Deterministic normalizer for Champions team drafts.
+
+Runs before the validator. Fixes common surface-level issues (case,
+aliases, whitespace, fuzzy move spelling) and logs every change so
+the audit trail can detect LLM drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
+
+# Minimal alias table — extend as real data exposes gaps. Keys are
+# casefolded inputs; values are canonical Pokemon names in the dex.
+POKEMON_ALIASES: dict[str, str] = {
+    "urshifu-s": "Urshifu-Single-Strike",
+    "urshifu-r": "Urshifu-Rapid-Strike",
+    "ogerpon-w": "Ogerpon-Wellspring",
+    "ogerpon-h": "Ogerpon-Hearthflame",
+    "ogerpon-c": "Ogerpon-Cornerstone",
+    "landorus-t": "Landorus-Therian",
+    "landorus-i": "Landorus-Incarnate",
+}
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Classic iterative Levenshtein distance."""
+    if len(a) < len(b):
+        a, b = b, a
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        curr = [i]
+        for j, cb in enumerate(b, start=1):
+            ins = curr[j - 1] + 1
+            dele = prev[j] + 1
+            sub = prev[j - 1] + (0 if ca == cb else 1)
+            curr.append(min(ins, dele, sub))
+        prev = curr
+    return prev[-1]
+
+
+def _closest_move(name: str, known: set[str]) -> str | None:
+    """Return the closest known move within distance 2, else None."""
+    best: tuple[int, str] | None = None
+    for known_name in known:
+        d = _levenshtein(name.casefold(), known_name.casefold())
+        if d <= 2 and (best is None or d < best[0]):
+            best = (d, known_name)
+    return best[1] if best else None
+
+
+def _normalize_pokemon(
+    poke: ChampionsTeamPokemon,
+    *,
+    known_moves: set[str] | None,
+    log: list[str],
+) -> ChampionsTeamPokemon:
+    updates: dict[str, object] = {}
+
+    alias = POKEMON_ALIASES.get(poke.pokemon.casefold())
+    if alias and alias != poke.pokemon:
+        log.append(f"pokemon_alias:{poke.pokemon}->{alias}")
+        updates["pokemon"] = alias
+
+    if poke.nature:
+        title = poke.nature.strip().title()
+        if title != poke.nature:
+            log.append(f"nature_case:{poke.nature}->{title}")
+            updates["nature"] = title
+
+    if poke.tera_type:
+        title = poke.tera_type.strip().title()
+        if title != poke.tera_type:
+            log.append(f"tera_case:{poke.tera_type}->{title}")
+            updates["tera_type"] = title
+
+    if poke.item and "(consumed)" in poke.item.casefold():
+        stripped = poke.item.replace("(consumed)", "").replace("(Consumed)", "").strip()
+        log.append(f"item_strip_consumed:{poke.item}->{stripped}")
+        updates["item"] = stripped
+
+    if known_moves:
+        for attr in ("move1", "move2", "move3", "move4"):
+            current = getattr(poke, attr)
+            if not current or current in known_moves:
+                continue
+            fixed = _closest_move(current, known_moves)
+            if fixed and fixed != current:
+                log.append(f"move_fuzzy:{current}->{fixed}")
+                updates[attr] = fixed
+
+    if not updates:
+        return poke
+    return replace(poke, **updates)
+
+
+def normalize(
+    draft: ChampionsTeamDraft,
+    *,
+    known_moves: set[str] | None = None,
+) -> tuple[ChampionsTeamDraft, list[str]]:
+    """Return a normalized copy of the draft plus a list of change entries."""
+    log: list[str] = []
+    new_pokes = [
+        _normalize_pokemon(p, known_moves=known_moves, log=log) for p in draft.pokemon
+    ]
+    return replace(draft, pokemon=new_pokes), log

--- a/src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py
@@ -1,8 +1,9 @@
 """Deterministic normalizer for Champions team drafts.
 
 Runs before the validator. Fixes common surface-level issues (case,
-aliases, whitespace, fuzzy move spelling) and logs every change so
-the audit trail can detect LLM drift.
+aliases, whitespace, fuzzy move spelling) and logs every change so the
+stored ``normalizations`` column provides an auditable diff between
+raw extraction and final values.
 """
 
 from __future__ import annotations

--- a/src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py
@@ -102,7 +102,5 @@ def normalize(
 ) -> tuple[ChampionsTeamDraft, list[str]]:
     """Return a normalized copy of the draft plus a list of change entries."""
     log: list[str] = []
-    new_pokes = [
-        _normalize_pokemon(p, known_moves=known_moves, log=log) for p in draft.pokemon
-    ]
+    new_pokes = [_normalize_pokemon(p, known_moves=known_moves, log=log) for p in draft.pokemon]
     return replace(draft, pokemon=new_pokes), log

--- a/src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/normalizer.py
@@ -8,9 +8,12 @@ raw extraction and final values.
 
 from __future__ import annotations
 
+import re
 from dataclasses import replace
 
 from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
+
+_CONSUMED_RE = re.compile(r"\(consumed\)", flags=re.IGNORECASE)
 
 # Minimal alias table — extend as real data exposes gaps. Keys are
 # casefolded inputs; values are canonical Pokemon names in the dex.
@@ -76,8 +79,8 @@ def _normalize_pokemon(
             log.append(f"tera_case:{poke.tera_type}->{title}")
             updates["tera_type"] = title
 
-    if poke.item and "(consumed)" in poke.item.casefold():
-        stripped = poke.item.replace("(consumed)", "").replace("(Consumed)", "").strip()
+    if poke.item and _CONSUMED_RE.search(poke.item):
+        stripped = _CONSUMED_RE.sub("", poke.item).strip()
         log.append(f"item_strip_consumed:{poke.item}->{stripped}")
         updates["item"] = stripped
 

--- a/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
@@ -1,7 +1,9 @@
 """Top-level ingestion orchestrator.
 
 Routes a URL through the classifier to the appropriate tier handler,
-then normalizes, validates, and writes (or queues) the result.
+then normalizes, validates, and writes the team to ChampionsTeam with
+either ``auto`` or ``review_pending`` ingestion_status based on
+confidence.
 
 Additional tiers are added by inserting a branch in ``ingest_url``
 and wiring a ``_fetch_tierN`` coroutine.
@@ -34,8 +36,9 @@ logger = logging.getLogger(__name__)
 AUTO_WRITE_THRESHOLD = 0.85
 
 IngestStatus = Literal["auto", "review_pending", "fetch_failed", "parse_failed", "rejected"]
-# Subset actually persisted to ChampionsTeam.ingestion_status — terminal
-# statuses (fetch_failed, parse_failed, rejected) return before any DB write.
+# Subset actually persisted to ChampionsTeam.ingestion_status. Other
+# IngestStatus values are transient: either we never got to a DB write
+# (fetch_failed / parse_failed / rejected) or the write itself raised.
 WrittenIngestionStatus = Literal["auto", "review_pending"]
 
 
@@ -52,6 +55,9 @@ async def _fetch_tier1(url: str) -> FetchResult[ChampionsTeamDraft]:
     if not fetched.success or not fetched.data:
         if fetched.error is not None:
             return FetchResult.fail(fetched.error)
+        # Fetch reported success but returned no body — surface this so
+        # rate-limit HTML or empty 200 responses don't vanish silently.
+        logger.warning("pokepaste fetch succeeded with empty body: url=%s", url)
         return FetchResult.ok(None)
     try:
         draft = parse_pokepaste_to_champions_draft(fetched.data, source_url=url)
@@ -70,6 +76,7 @@ async def _fetch_tier1(url: str) -> FetchResult[ChampionsTeamDraft]:
 
 
 def _score(draft: ChampionsTeamDraft, soft_count: int) -> float:
+    """Tier baseline minus 0.1 per soft-failure code, clamped at 0.0."""
     return max(0.0, draft.tier_baseline_confidence - 0.1 * soft_count)
 
 
@@ -88,7 +95,10 @@ async def ingest_url(url: str, *, db_path: Path | None = None) -> IngestResult:
         return IngestResult(status="rejected", reason="tier_not_implemented")
 
     if not fetched.success:
-        return IngestResult(status="fetch_failed", reason=str(fetched.error))
+        # ServiceError.message is the actionable text; its dataclass repr
+        # buries the message behind category/service/is_recoverable noise.
+        reason = fetched.error.message if fetched.error is not None else "unknown_error"
+        return IngestResult(status="fetch_failed", reason=reason)
     if fetched.data is None:
         return IngestResult(status="parse_failed", reason="empty_parse")
 

--- a/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
@@ -3,36 +3,39 @@
 Routes a URL through the classifier to the appropriate tier handler,
 then normalizes, validates, and writes (or queues) the result.
 
-Phases 3-6 will register additional tier handlers by extending
-``_TIER_HANDLERS``.
+Additional tiers are added by inserting a branch in ``ingest_url``
+and wiring a ``_fetch_tierN`` coroutine.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from smogon_vgc_mcp.database.champions_team_queries import (
     compute_team_fingerprint,
     write_or_queue_team,
 )
 from smogon_vgc_mcp.database.models import ChampionsTeam, ChampionsTeamDraft
-from smogon_vgc_mcp.database.schema import get_connection
+from smogon_vgc_mcp.database.schema import get_connection, init_database
 from smogon_vgc_mcp.fetcher.ingestion.classifier import Tier, classify_url
 from smogon_vgc_mcp.fetcher.ingestion.normalizer import normalize
 from smogon_vgc_mcp.fetcher.ingestion.tier1_pokepaste import (
     parse_pokepaste_to_champions_draft,
 )
 from smogon_vgc_mcp.fetcher.ingestion.validator import validate
-from smogon_vgc_mcp.fetcher.pokepaste import fetch_pokepaste  # re-imported for patchability
-from smogon_vgc_mcp.resilience import FetchResult
+from smogon_vgc_mcp.fetcher.pokepaste import fetch_pokepaste
+from smogon_vgc_mcp.resilience import ErrorCategory, FetchResult, ServiceError
 
 AUTO_WRITE_THRESHOLD = 0.85
+
+IngestStatus = Literal["auto", "review_pending", "fetch_failed", "parse_failed", "rejected"]
 
 
 @dataclass(frozen=True)
 class IngestResult:
-    status: str  # 'auto' | 'review_pending' | 'fetch_failed' | 'parse_failed' | 'rejected'
+    status: IngestStatus
     team_row_id: int | None = None
     confidence: float | None = None
     reason: str | None = None
@@ -42,7 +45,18 @@ async def _fetch_tier1(url: str) -> FetchResult[ChampionsTeamDraft]:
     fetched = await fetch_pokepaste(url)
     if not fetched.success or not fetched.data:
         return FetchResult.fail(fetched.error) if fetched.error else FetchResult.ok(None)
-    draft = parse_pokepaste_to_champions_draft(fetched.data, source_url=url)
+    try:
+        draft = parse_pokepaste_to_champions_draft(fetched.data, source_url=url)
+    except Exception as exc:
+        return FetchResult.fail(
+            ServiceError(
+                category=ErrorCategory.PARSE_ERROR,
+                service="pokepaste",
+                message=f"Failed to parse pokepaste from {url}: {exc}",
+            )
+        )
+    if not draft.pokemon:
+        return FetchResult.ok(None)
     return FetchResult.ok(draft)
 
 
@@ -51,6 +65,7 @@ def _score(draft: ChampionsTeamDraft, soft_count: int) -> float:
 
 
 async def ingest_url(url: str, *, db_path: Path | None = None) -> IngestResult:
+    await init_database(db_path)
     tier = classify_url(url)
 
     if tier == Tier.UNKNOWN:
@@ -85,12 +100,19 @@ async def ingest_url(url: str, *, db_path: Path | None = None) -> IngestResult:
         source_url=normalized.source_url,
         ingestion_status=status,
         confidence_score=confidence,
-        review_reasons=report.hard_failures + report.soft_failures or None,
+        review_reasons=list(report.hard_failures + report.soft_failures) or None,
         normalizations=norm_log or None,
         pokemon=normalized.pokemon,
     )
 
-    async with get_connection(db_path) as db:
-        row_id = await write_or_queue_team(db, team)
+    try:
+        async with get_connection(db_path) as db:
+            row_id = await write_or_queue_team(db, team)
+    except Exception as exc:
+        return IngestResult(
+            status="parse_failed",
+            confidence=confidence,
+            reason=f"db_write_error: {exc}",
+        )
 
     return IngestResult(status=status, team_row_id=row_id, confidence=confidence)

--- a/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
@@ -115,10 +115,11 @@ async def load_dex_lookup(db_path: Path | None = None) -> DexLookup | None:
                 JOIN champions_dex_moves m ON m.id = l.move_id
                 """
             )
-    except Exception:
+    except (aiosqlite.Error, OSError):
         # A missing/corrupt dex should not take down the whole ingest
         # run. Skip the optional checks and let the pipeline proceed on
-        # SP/shape/vocab validation alone.
+        # SP/shape/vocab validation alone. Narrower than `Exception` so
+        # programming bugs (TypeError, KeyError) still surface.
         logger.exception("load_dex_lookup: failed to load champions dex; skipping identity checks")
         return None
 

--- a/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
@@ -88,31 +88,39 @@ def _score(draft: ChampionsTeamDraft, soft_count: int) -> float:
 async def load_dex_lookup(db_path: Path | None = None) -> DexLookup | None:
     """Build a dex lookup keyed on casefolded Pokemon name.
 
-    Returns None if the ``champions_dex_pokemon`` table has no rows —
-    callers should treat that as "dex not loaded" and skip identity/
-    legality checks. Logs once at warning level when empty so the
+    Returns None if the ``champions_dex_pokemon`` table has no rows or
+    if the query fails for any reason — callers should treat that as
+    "dex not loaded" and skip identity/legality checks. Logs once at
+    warning level when empty and at error level on DB failure, so the
     silent-skip condition is visible in production.
     """
-    async with get_connection(db_path) as db:
-        db.row_factory = aiosqlite.Row
-        pokemon_rows = await db.execute_fetchall(
-            "SELECT name, ability1, ability2, ability_hidden FROM champions_dex_pokemon"
-        )
-        if not pokemon_rows:
-            logger.warning(
-                "load_dex_lookup: champions_dex_pokemon is empty — "
-                "identity/legality checks will be skipped"
+    try:
+        async with get_connection(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            pokemon_rows = await db.execute_fetchall(
+                "SELECT name, ability1, ability2, ability_hidden FROM champions_dex_pokemon"
             )
-            return None
+            if not pokemon_rows:
+                logger.warning(
+                    "load_dex_lookup: champions_dex_pokemon is empty — "
+                    "identity/legality checks will be skipped"
+                )
+                return None
 
-        learnset_rows = await db.execute_fetchall(
-            """
-            SELECT p.name AS pokemon_name, m.name AS move_name
-            FROM champions_dex_learnsets l
-            JOIN champions_dex_pokemon p ON p.id = l.pokemon_id
-            JOIN champions_dex_moves m ON m.id = l.move_id
-            """
-        )
+            learnset_rows = await db.execute_fetchall(
+                """
+                SELECT p.name AS pokemon_name, m.name AS move_name
+                FROM champions_dex_learnsets l
+                JOIN champions_dex_pokemon p ON p.id = l.pokemon_id
+                JOIN champions_dex_moves m ON m.id = l.move_id
+                """
+            )
+    except Exception:
+        # A missing/corrupt dex should not take down the whole ingest
+        # run. Skip the optional checks and let the pipeline proceed on
+        # SP/shape/vocab validation alone.
+        logger.exception("load_dex_lookup: failed to load champions dex; skipping identity checks")
+        return None
 
     lookup: DexLookup = {}
     for row in pokemon_rows:
@@ -133,9 +141,6 @@ async def ingest_url(
     dex_lookup: DexLookup | None = None,
 ) -> IngestResult:
     await init_database(db_path)
-    if dex_lookup is None:
-        dex_lookup = await load_dex_lookup(db_path)
-
     tier = classify_url(url)
 
     if tier == Tier.UNKNOWN:
@@ -151,10 +156,21 @@ async def ingest_url(
     if not fetched.success:
         # ServiceError.message is the actionable text; its dataclass repr
         # buries the message behind category/service/is_recoverable noise.
-        reason = fetched.error.message if fetched.error is not None else "unknown_error"
+        err = fetched.error
+        reason = err.message if err is not None else "unknown_error"
+        # A wrapped parse exception from _fetch_tier1 must surface as
+        # parse_failed, not fetch_failed — the two map to different CLI
+        # exit codes (4 vs 3) and different operator retry strategies.
+        if err is not None and err.category == ErrorCategory.PARSE_ERROR:
+            return IngestResult(status="parse_failed", reason=reason)
         return IngestResult(status="fetch_failed", reason=reason)
     if fetched.data is None:
         return IngestResult(status="parse_failed", reason="empty_parse")
+
+    # Load the dex now that we know the URL will actually be processed,
+    # so rejected/fetch-failed URLs don't pay the round-trip cost.
+    if dex_lookup is None:
+        dex_lookup = await load_dex_lookup(db_path)
 
     draft = fetched.data
     normalized, norm_log = normalize(draft)

--- a/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+import aiosqlite
+
 from smogon_vgc_mcp.database.champions_team_queries import (
     compute_team_fingerprint,
     write_or_queue_team,
@@ -27,7 +29,7 @@ from smogon_vgc_mcp.fetcher.ingestion.normalizer import normalize
 from smogon_vgc_mcp.fetcher.ingestion.tier1_pokepaste import (
     parse_pokepaste_to_champions_draft,
 )
-from smogon_vgc_mcp.fetcher.ingestion.validator import validate
+from smogon_vgc_mcp.fetcher.ingestion.validator import DexLookup, validate
 from smogon_vgc_mcp.fetcher.pokepaste import fetch_pokepaste
 from smogon_vgc_mcp.resilience import ErrorCategory, FetchResult, ServiceError
 
@@ -35,10 +37,13 @@ logger = logging.getLogger(__name__)
 
 AUTO_WRITE_THRESHOLD = 0.85
 
-IngestStatus = Literal["auto", "review_pending", "fetch_failed", "parse_failed", "rejected"]
+IngestStatus = Literal[
+    "auto", "review_pending", "fetch_failed", "parse_failed", "db_error", "rejected"
+]
 # Subset actually persisted to ChampionsTeam.ingestion_status. Other
 # IngestStatus values are transient: either we never got to a DB write
-# (fetch_failed / parse_failed / rejected) or the write itself raised.
+# (fetch_failed / parse_failed / rejected) or the write itself raised
+# (db_error).
 WrittenIngestionStatus = Literal["auto", "review_pending"]
 
 
@@ -80,8 +85,57 @@ def _score(draft: ChampionsTeamDraft, soft_count: int) -> float:
     return max(0.0, draft.tier_baseline_confidence - 0.1 * soft_count)
 
 
-async def ingest_url(url: str, *, db_path: Path | None = None) -> IngestResult:
+async def load_dex_lookup(db_path: Path | None = None) -> DexLookup | None:
+    """Build a dex lookup keyed on casefolded Pokemon name.
+
+    Returns None if the ``champions_dex_pokemon`` table has no rows —
+    callers should treat that as "dex not loaded" and skip identity/
+    legality checks. Logs once at warning level when empty so the
+    silent-skip condition is visible in production.
+    """
+    async with get_connection(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        pokemon_rows = await db.execute_fetchall(
+            "SELECT name, ability1, ability2, ability_hidden FROM champions_dex_pokemon"
+        )
+        if not pokemon_rows:
+            logger.warning(
+                "load_dex_lookup: champions_dex_pokemon is empty — "
+                "identity/legality checks will be skipped"
+            )
+            return None
+
+        learnset_rows = await db.execute_fetchall(
+            """
+            SELECT p.name AS pokemon_name, m.name AS move_name
+            FROM champions_dex_learnsets l
+            JOIN champions_dex_pokemon p ON p.id = l.pokemon_id
+            JOIN champions_dex_moves m ON m.id = l.move_id
+            """
+        )
+
+    lookup: DexLookup = {}
+    for row in pokemon_rows:
+        abilities = [row[k] for k in ("ability1", "ability2", "ability_hidden") if row[k]]
+        lookup[row["name"].casefold()] = {"abilities": abilities, "moves": []}
+    for row in learnset_rows:
+        key = row["pokemon_name"].casefold()
+        entry = lookup.get(key)
+        if entry is not None:
+            entry["moves"].append(row["move_name"])
+    return lookup
+
+
+async def ingest_url(
+    url: str,
+    *,
+    db_path: Path | None = None,
+    dex_lookup: DexLookup | None = None,
+) -> IngestResult:
     await init_database(db_path)
+    if dex_lookup is None:
+        dex_lookup = await load_dex_lookup(db_path)
+
     tier = classify_url(url)
 
     if tier == Tier.UNKNOWN:
@@ -104,7 +158,7 @@ async def ingest_url(url: str, *, db_path: Path | None = None) -> IngestResult:
 
     draft = fetched.data
     normalized, norm_log = normalize(draft)
-    report = validate(normalized)
+    report = validate(normalized, dex_lookup=dex_lookup)
 
     if report.hard_failures:
         confidence = 0.0
@@ -132,7 +186,7 @@ async def ingest_url(url: str, *, db_path: Path | None = None) -> IngestResult:
     except Exception as exc:
         logger.exception("ingest_url: db write failed for url=%s", url)
         return IngestResult(
-            status="fetch_failed",
+            status="db_error",
             confidence=confidence,
             reason=f"db_write_error: {exc}",
         )

--- a/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
@@ -1,0 +1,96 @@
+"""Top-level ingestion orchestrator.
+
+Routes a URL through the classifier to the appropriate tier handler,
+then normalizes, validates, and writes (or queues) the result.
+
+Phases 3-6 will register additional tier handlers by extending
+``_TIER_HANDLERS``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from smogon_vgc_mcp.database.champions_team_queries import (
+    compute_team_fingerprint,
+    write_or_queue_team,
+)
+from smogon_vgc_mcp.database.models import ChampionsTeam, ChampionsTeamDraft
+from smogon_vgc_mcp.database.schema import get_connection
+from smogon_vgc_mcp.fetcher.ingestion.classifier import Tier, classify_url
+from smogon_vgc_mcp.fetcher.ingestion.normalizer import normalize
+from smogon_vgc_mcp.fetcher.ingestion.tier1_pokepaste import (
+    parse_pokepaste_to_champions_draft,
+)
+from smogon_vgc_mcp.fetcher.ingestion.validator import validate
+from smogon_vgc_mcp.fetcher.pokepaste import fetch_pokepaste  # re-imported for patchability
+from smogon_vgc_mcp.resilience import FetchResult
+
+AUTO_WRITE_THRESHOLD = 0.85
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    status: str  # 'auto' | 'review_pending' | 'fetch_failed' | 'parse_failed' | 'rejected'
+    team_row_id: int | None = None
+    confidence: float | None = None
+    reason: str | None = None
+
+
+async def _fetch_tier1(url: str) -> FetchResult[ChampionsTeamDraft]:
+    fetched = await fetch_pokepaste(url)
+    if not fetched.success or not fetched.data:
+        return FetchResult.fail(fetched.error) if fetched.error else FetchResult.ok(None)
+    draft = parse_pokepaste_to_champions_draft(fetched.data, source_url=url)
+    return FetchResult.ok(draft)
+
+
+def _score(draft: ChampionsTeamDraft, soft_count: int) -> float:
+    return max(0.0, draft.tier_baseline_confidence - 0.1 * soft_count)
+
+
+async def ingest_url(url: str, *, db_path: Path | None = None) -> IngestResult:
+    tier = classify_url(url)
+
+    if tier == Tier.UNKNOWN:
+        return IngestResult(status="rejected", reason="classifier_unknown_tier")
+    if tier in (Tier.X, Tier.BLOG):
+        return IngestResult(status="rejected", reason="tier_not_implemented")
+
+    if tier == Tier.POKEPASTE:
+        fetched = await _fetch_tier1(url)
+    else:
+        return IngestResult(status="rejected", reason="tier_not_implemented")
+
+    if not fetched.success:
+        return IngestResult(status="fetch_failed", reason=str(fetched.error))
+    if fetched.data is None:
+        return IngestResult(status="parse_failed", reason="empty_parse")
+
+    draft = fetched.data
+    normalized, norm_log = normalize(draft)
+    report = validate(normalized)
+
+    if report.hard_failures:
+        confidence = 0.0
+    else:
+        confidence = _score(normalized, len(report.soft_failures))
+
+    status = "auto" if confidence >= AUTO_WRITE_THRESHOLD else "review_pending"
+
+    team = ChampionsTeam(
+        team_id=compute_team_fingerprint(normalized.pokemon),
+        source_type=normalized.source_type,
+        source_url=normalized.source_url,
+        ingestion_status=status,
+        confidence_score=confidence,
+        review_reasons=report.hard_failures + report.soft_failures or None,
+        normalizations=norm_log or None,
+        pokemon=normalized.pokemon,
+    )
+
+    async with get_connection(db_path) as db:
+        row_id = await write_or_queue_team(db, team)
+
+    return IngestResult(status=status, team_row_id=row_id, confidence=confidence)

--- a/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
@@ -12,6 +12,7 @@ and wiring a ``_fetch_tierN`` coroutine.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -57,7 +58,7 @@ class IngestResult:
 
 async def _fetch_tier1(url: str) -> FetchResult[ChampionsTeamDraft]:
     fetched = await fetch_pokepaste(url)
-    if not fetched.success or not fetched.data:
+    if not fetched.success or fetched.data is None or fetched.data == "":
         if fetched.error is not None:
             return FetchResult.fail(fetched.error)
         # Empty body on a 2xx (e.g. rate-limit HTML scrubbed or a CDN
@@ -67,10 +68,12 @@ async def _fetch_tier1(url: str) -> FetchResult[ChampionsTeamDraft]:
         return FetchResult.ok(None)
     try:
         draft = parse_pokepaste_to_champions_draft(fetched.data, source_url=url)
-    except (ValueError, KeyError, IndexError, AttributeError, TypeError) as exc:
+    except (ValueError, KeyError, IndexError, AttributeError, TypeError, re.error) as exc:
         # Narrow catch — parser bugs surface as real parse errors; let
         # system-level failures (MemoryError, RecursionError) propagate
         # so a resource-exhaustion crash isn't mislabeled parse_failed.
+        # re.error is included because the parser uses regex and any
+        # future dynamic pattern would raise this on malformed input.
         return FetchResult.fail(
             ServiceError(
                 category=ErrorCategory.PARSE_ERROR,
@@ -184,7 +187,12 @@ async def ingest_url(
         dex_lookup = await load_dex_lookup(db_path)
 
     draft = fetched.data
-    normalized, norm_log = normalize(draft)
+    # Flatten dex into a known-moves set so the normalizer's fuzzy-move
+    # correction actually fires in production (no-op when dex is absent).
+    known_moves: set[str] | None = None
+    if dex_lookup is not None:
+        known_moves = {m for entry in dex_lookup.values() for m in entry["moves"]}
+    normalized, norm_log = normalize(draft, known_moves=known_moves)
     report = validate(normalized, dex_lookup=dex_lookup)
 
     if report.hard_failures:
@@ -210,11 +218,12 @@ async def ingest_url(
     try:
         async with get_connection(db_path) as db:
             row_id = await write_or_queue_team(db, team)
-    except (aiosqlite.Error, OSError) as exc:
-        # Narrow catch — only genuine DB/disk failures map to db_error.
-        # Programmer bugs (TypeError/AttributeError) propagate so they
-        # surface as real crashes instead of silently re-queuing under
-        # a misleading "retry the DB write" signal.
+    except (aiosqlite.Error, OSError, RuntimeError) as exc:
+        # Narrow catch — genuine DB/disk failures and write_or_queue_team's
+        # RuntimeError for a missing lastrowid (a DB-layer contract
+        # violation, not a programming bug) both bucket to db_error.
+        # Programmer bugs (TypeError/AttributeError) still propagate so
+        # they surface as real crashes instead of silently re-queuing.
         logger.exception("ingest_url: db write failed for url=%s", url)
         return IngestResult(
             status="db_error",

--- a/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
@@ -60,13 +60,17 @@ async def _fetch_tier1(url: str) -> FetchResult[ChampionsTeamDraft]:
     if not fetched.success or not fetched.data:
         if fetched.error is not None:
             return FetchResult.fail(fetched.error)
-        # Fetch reported success but returned no body — surface this so
-        # rate-limit HTML or empty 200 responses don't vanish silently.
+        # Empty body on a 2xx (e.g. rate-limit HTML scrubbed or a CDN
+        # 200-with-no-content). Logged at warning so the later
+        # parse_failed(empty_parse) bucket is explainable in logs.
         logger.warning("pokepaste fetch succeeded with empty body: url=%s", url)
         return FetchResult.ok(None)
     try:
         draft = parse_pokepaste_to_champions_draft(fetched.data, source_url=url)
-    except Exception as exc:
+    except (ValueError, KeyError, IndexError, AttributeError, TypeError) as exc:
+        # Narrow catch — parser bugs surface as real parse errors; let
+        # system-level failures (MemoryError, RecursionError) propagate
+        # so a resource-exhaustion crash isn't mislabeled parse_failed.
         return FetchResult.fail(
             ServiceError(
                 category=ErrorCategory.PARSE_ERROR,
@@ -140,8 +144,14 @@ async def ingest_url(
     *,
     db_path: Path | None = None,
     dex_lookup: DexLookup | None = None,
+    skip_init: bool = False,
 ) -> IngestResult:
-    await init_database(db_path)
+    # Batch callers that already initialized the DB (e.g. the sheet
+    # runner) can pass ``skip_init=True`` to avoid rerunning migrations
+    # per row. Single-URL callers leave it False so the first CLI run
+    # on a fresh install still bootstraps the schema.
+    if not skip_init:
+        await init_database(db_path)
     tier = classify_url(url)
 
     if tier == Tier.UNKNOWN:
@@ -200,7 +210,11 @@ async def ingest_url(
     try:
         async with get_connection(db_path) as db:
             row_id = await write_or_queue_team(db, team)
-    except Exception as exc:
+    except (aiosqlite.Error, OSError) as exc:
+        # Narrow catch — only genuine DB/disk failures map to db_error.
+        # Programmer bugs (TypeError/AttributeError) propagate so they
+        # surface as real crashes instead of silently re-queuing under
+        # a misleading "retry the DB write" signal.
         logger.exception("ingest_url: db write failed for url=%s", url)
         return IngestResult(
             status="db_error",

--- a/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
@@ -9,6 +9,7 @@ and wiring a ``_fetch_tierN`` coroutine.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -28,9 +29,14 @@ from smogon_vgc_mcp.fetcher.ingestion.validator import validate
 from smogon_vgc_mcp.fetcher.pokepaste import fetch_pokepaste
 from smogon_vgc_mcp.resilience import ErrorCategory, FetchResult, ServiceError
 
+logger = logging.getLogger(__name__)
+
 AUTO_WRITE_THRESHOLD = 0.85
 
 IngestStatus = Literal["auto", "review_pending", "fetch_failed", "parse_failed", "rejected"]
+# Subset actually persisted to ChampionsTeam.ingestion_status — terminal
+# statuses (fetch_failed, parse_failed, rejected) return before any DB write.
+WrittenIngestionStatus = Literal["auto", "review_pending"]
 
 
 @dataclass(frozen=True)
@@ -44,7 +50,9 @@ class IngestResult:
 async def _fetch_tier1(url: str) -> FetchResult[ChampionsTeamDraft]:
     fetched = await fetch_pokepaste(url)
     if not fetched.success or not fetched.data:
-        return FetchResult.fail(fetched.error) if fetched.error else FetchResult.ok(None)
+        if fetched.error is not None:
+            return FetchResult.fail(fetched.error)
+        return FetchResult.ok(None)
     try:
         draft = parse_pokepaste_to_champions_draft(fetched.data, source_url=url)
     except Exception as exc:
@@ -56,6 +64,7 @@ async def _fetch_tier1(url: str) -> FetchResult[ChampionsTeamDraft]:
             )
         )
     if not draft.pokemon:
+        logger.warning("pokepaste parsed to zero pokemon: url=%s", url)
         return FetchResult.ok(None)
     return FetchResult.ok(draft)
 
@@ -92,7 +101,9 @@ async def ingest_url(url: str, *, db_path: Path | None = None) -> IngestResult:
     else:
         confidence = _score(normalized, len(report.soft_failures))
 
-    status = "auto" if confidence >= AUTO_WRITE_THRESHOLD else "review_pending"
+    status: WrittenIngestionStatus = (
+        "auto" if confidence >= AUTO_WRITE_THRESHOLD else "review_pending"
+    )
 
     team = ChampionsTeam(
         team_id=compute_team_fingerprint(normalized.pokemon),
@@ -109,8 +120,9 @@ async def ingest_url(url: str, *, db_path: Path | None = None) -> IngestResult:
         async with get_connection(db_path) as db:
             row_id = await write_or_queue_team(db, team)
     except Exception as exc:
+        logger.exception("ingest_url: db write failed for url=%s", url)
         return IngestResult(
-            status="parse_failed",
+            status="fetch_failed",
             confidence=confidence,
             reason=f"db_write_error: {exc}",
         )

--- a/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
@@ -122,6 +122,16 @@ async def load_dex_lookup(db_path: Path | None = None) -> DexLookup | None:
                 JOIN champions_dex_moves m ON m.id = l.move_id
                 """
             )
+            if not learnset_rows:
+                # Pokemon rows exist but the learnset join is empty —
+                # identity checks will pass while every move will flag
+                # as move_illegal, flooding teams into review_pending.
+                # Surface the condition so operators can spot the broken
+                # dex state without having to diff soft-failure codes.
+                logger.warning(
+                    "load_dex_lookup: champions_dex_learnsets is empty — "
+                    "all move checks will flag as move_illegal"
+                )
     except (aiosqlite.Error, OSError):
         # A missing/corrupt dex should not take down the whole ingest
         # run. Skip the optional checks and let the pipeline proceed on

--- a/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/pipeline.py
@@ -124,14 +124,16 @@ async def load_dex_lookup(db_path: Path | None = None) -> DexLookup | None:
             )
             if not learnset_rows:
                 # Pokemon rows exist but the learnset join is empty —
-                # identity checks will pass while every move will flag
-                # as move_illegal, flooding teams into review_pending.
-                # Surface the condition so operators can spot the broken
-                # dex state without having to diff soft-failure codes.
+                # returning a partial lookup would pass identity checks
+                # while flagging every move as move_illegal, flooding
+                # every team into review_pending. Returning None instead
+                # skips all dex-dependent checks, matching the
+                # "dex not loaded" contract documented in the docstring.
                 logger.warning(
                     "load_dex_lookup: champions_dex_learnsets is empty — "
-                    "all move checks will flag as move_illegal"
+                    "skipping all dex-dependent checks"
                 )
+                return None
     except (aiosqlite.Error, OSError):
         # A missing/corrupt dex should not take down the whole ingest
         # run. Skip the optional checks and let the pipeline proceed on

--- a/src/smogon_vgc_mcp/fetcher/ingestion/tier1_pokepaste.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/tier1_pokepaste.py
@@ -1,0 +1,59 @@
+"""Tier 1 pokepaste handler for Champions ingestion.
+
+Reuses the existing pokepaste parser and translates its Gen 9 EV
+output directly into Champions SP fields (same numeric values — a
+pokepaste authored for Champions uses identical text syntax but the
+numbers now represent Stat Points).
+"""
+
+from __future__ import annotations
+
+from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
+from smogon_vgc_mcp.fetcher.pokepaste import fetch_pokepaste, parse_pokepaste
+from smogon_vgc_mcp.resilience import FetchResult
+
+
+def parse_pokepaste_to_champions_draft(
+    text: str,
+    *,
+    source_url: str,
+) -> ChampionsTeamDraft:
+    """Parse raw pokepaste text into a ChampionsTeamDraft."""
+    parsed = parse_pokepaste(text)
+    pokemon = [
+        ChampionsTeamPokemon(
+            slot=tp.slot,
+            pokemon=tp.pokemon,
+            item=tp.item,
+            ability=tp.ability,
+            nature=tp.nature,
+            tera_type=tp.tera_type,
+            level=50,
+            sp_hp=tp.hp_ev,
+            sp_atk=tp.atk_ev,
+            sp_def=tp.def_ev,
+            sp_spa=tp.spa_ev,
+            sp_spd=tp.spd_ev,
+            sp_spe=tp.spe_ev,
+            move1=tp.move1,
+            move2=tp.move2,
+            move3=tp.move3,
+            move4=tp.move4,
+        )
+        for tp in parsed
+    ]
+    return ChampionsTeamDraft(
+        source_type="pokepaste",
+        source_url=source_url,
+        tier_baseline_confidence=1.0,
+        pokemon=pokemon,
+    )
+
+
+async def fetch_and_parse_pokepaste(url: str) -> FetchResult[ChampionsTeamDraft]:
+    """Fetch a pokepaste URL and return a ChampionsTeamDraft."""
+    fetched = await fetch_pokepaste(url)
+    if not fetched.success or not fetched.data:
+        return FetchResult.fail(fetched.error) if fetched.error else FetchResult.ok(None)
+    draft = parse_pokepaste_to_champions_draft(fetched.data, source_url=url)
+    return FetchResult.ok(draft)

--- a/src/smogon_vgc_mcp/fetcher/ingestion/tier1_pokepaste.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/tier1_pokepaste.py
@@ -1,8 +1,12 @@
 """Tier 1 pokepaste handler for Champions ingestion.
 
 Reuses the existing pokepaste parser and maps its EV fields directly
-onto Champions SP fields (same numeric values, same ``EVs:`` line
-syntax — the numbers are reinterpreted as Stat Points).
+onto Champions SP fields (same ``EVs:`` line syntax — the numbers are
+reinterpreted as Stat Points). Standard VGC spreads (e.g. 252/252/4)
+will exceed Champions SP bounds (max 32 per stat, 66 total) and fail
+validation as hard failures; this is intentional — the ingestion
+pipeline uses the validator to reject non-Champions pastes rather
+than silently truncating the values.
 """
 
 from __future__ import annotations

--- a/src/smogon_vgc_mcp/fetcher/ingestion/tier1_pokepaste.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/tier1_pokepaste.py
@@ -1,9 +1,8 @@
 """Tier 1 pokepaste handler for Champions ingestion.
 
-Reuses the existing pokepaste parser and translates its Gen 9 EV
-output directly into Champions SP fields (same numeric values — a
-pokepaste authored for Champions uses identical text syntax but the
-numbers now represent Stat Points).
+Reuses the existing pokepaste parser and maps its EV fields directly
+onto Champions SP fields (same numeric values, same ``EVs:`` line
+syntax — the numbers are reinterpreted as Stat Points).
 """
 
 from __future__ import annotations

--- a/src/smogon_vgc_mcp/fetcher/ingestion/tier1_pokepaste.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/tier1_pokepaste.py
@@ -9,8 +9,7 @@ numbers now represent Stat Points).
 from __future__ import annotations
 
 from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
-from smogon_vgc_mcp.fetcher.pokepaste import fetch_pokepaste, parse_pokepaste
-from smogon_vgc_mcp.resilience import FetchResult
+from smogon_vgc_mcp.fetcher.pokepaste import parse_pokepaste
 
 
 def parse_pokepaste_to_champions_draft(
@@ -48,12 +47,3 @@ def parse_pokepaste_to_champions_draft(
         tier_baseline_confidence=1.0,
         pokemon=pokemon,
     )
-
-
-async def fetch_and_parse_pokepaste(url: str) -> FetchResult[ChampionsTeamDraft]:
-    """Fetch a pokepaste URL and return a ChampionsTeamDraft."""
-    fetched = await fetch_pokepaste(url)
-    if not fetched.success or not fetched.data:
-        return FetchResult.fail(fetched.error) if fetched.error else FetchResult.ok(None)
-    draft = parse_pokepaste_to_champions_draft(fetched.data, source_url=url)
-    return FetchResult.ok(draft)

--- a/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
@@ -115,12 +115,18 @@ def _check_ability_and_moves(poke: ChampionsTeamPokemon, dex: DexLookup | None) 
     entry = dex.get(poke.pokemon.casefold())
     if entry is None:
         return []
+    # Case-fold both sides of the membership check. The dex stores names in
+    # their DB casing (e.g. "Protect", "Intimidate") while parsed pokepaste
+    # values vary (e.g. "protect", "PROTECT"). A case-sensitive compare
+    # would spuriously flag ability_illegal / move_illegal on every team.
+    abilities_cf = {a.casefold() for a in entry["abilities"]}
+    moves_cf = {m.casefold() for m in entry["moves"]}
     soft: list[str] = []
-    if poke.ability and poke.ability not in entry["abilities"]:
+    if poke.ability and poke.ability.casefold() not in abilities_cf:
         soft.append("ability_illegal")
     moves = [poke.move1, poke.move2, poke.move3, poke.move4]
     for move in moves:
-        if move and move not in entry["moves"]:
+        if move and move.casefold() not in moves_cf:
             soft.append("move_illegal")
     return soft
 

--- a/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
@@ -35,10 +35,24 @@ def _check_sp_numeric(poke: ChampionsTeamPokemon) -> list[str]:
     return reasons
 
 
+def _check_team_shape(pokes: list[ChampionsTeamPokemon]) -> list[str]:
+    reasons: list[str] = []
+    if not (1 <= len(pokes) <= 6):
+        reasons.append("slot_count")
+    names_cf = [p.pokemon.casefold() for p in pokes]
+    if len(set(names_cf)) != len(names_cf):
+        reasons.append("duplicate_species")
+    return reasons
+
+
 def validate(draft: ChampionsTeamDraft) -> ValidationReport:
     """Validate a team draft. Returns a ValidationReport."""
     hard: list[str] = []
     soft: list[str] = []
+
+    for code in _check_team_shape(draft.pokemon):
+        if code not in hard:
+            hard.append(code)
 
     for poke in draft.pokemon:
         for code in _check_sp_numeric(poke):

--- a/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
@@ -45,19 +45,58 @@ def _check_team_shape(pokes: list[ChampionsTeamPokemon]) -> list[str]:
     return reasons
 
 
-NATURES = frozenset({
-    "Hardy", "Lonely", "Brave", "Adamant", "Naughty",
-    "Bold", "Docile", "Relaxed", "Impish", "Lax",
-    "Timid", "Hasty", "Serious", "Jolly", "Naive",
-    "Modest", "Mild", "Quiet", "Bashful", "Rash",
-    "Calm", "Gentle", "Sassy", "Careful", "Quirky",
-})
+NATURES = frozenset(
+    {
+        "Hardy",
+        "Lonely",
+        "Brave",
+        "Adamant",
+        "Naughty",
+        "Bold",
+        "Docile",
+        "Relaxed",
+        "Impish",
+        "Lax",
+        "Timid",
+        "Hasty",
+        "Serious",
+        "Jolly",
+        "Naive",
+        "Modest",
+        "Mild",
+        "Quiet",
+        "Bashful",
+        "Rash",
+        "Calm",
+        "Gentle",
+        "Sassy",
+        "Careful",
+        "Quirky",
+    }
+)
 
-TYPES = frozenset({
-    "Normal", "Fire", "Water", "Electric", "Grass", "Ice",
-    "Fighting", "Poison", "Ground", "Flying", "Psychic", "Bug",
-    "Rock", "Ghost", "Dragon", "Dark", "Steel", "Fairy",
-})
+TYPES = frozenset(
+    {
+        "Normal",
+        "Fire",
+        "Water",
+        "Electric",
+        "Grass",
+        "Ice",
+        "Fighting",
+        "Poison",
+        "Ground",
+        "Flying",
+        "Psychic",
+        "Bug",
+        "Rock",
+        "Ghost",
+        "Dragon",
+        "Dark",
+        "Steel",
+        "Fairy",
+    }
+)
 
 DexLookup = dict[str, dict[str, list[str]]]  # name_casefold -> {"abilities": [...], "moves": [...]}
 
@@ -70,9 +109,7 @@ def _check_pokemon_identity(poke: ChampionsTeamPokemon, dex: DexLookup | None) -
     return []
 
 
-def _check_ability_and_moves(
-    poke: ChampionsTeamPokemon, dex: DexLookup | None
-) -> list[str]:
+def _check_ability_and_moves(poke: ChampionsTeamPokemon, dex: DexLookup | None) -> list[str]:
     if dex is None:
         return []
     entry = dex.get(poke.pokemon.casefold())

--- a/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
@@ -94,6 +94,7 @@ TYPES = frozenset(
         "Dark",
         "Steel",
         "Fairy",
+        "Stellar",
     }
 )
 
@@ -147,8 +148,8 @@ def validate(
     (``pokemon_unknown``) and ability/move-legality
     (``ability_illegal`` / ``move_illegal``) checks are skipped — the
     caller is responsible for supplying a dex when those checks are
-    desired. SP numeric, team-shape, and nature/tera vocab checks
-    always run.
+    desired. SP numeric, team-shape, nature/tera vocab, and move-count
+    checks always run regardless of ``dex_lookup``.
     """
     hard: list[str] = []
     soft: list[str] = []

--- a/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
@@ -45,6 +45,20 @@ def _check_team_shape(pokes: list[ChampionsTeamPokemon]) -> list[str]:
     return reasons
 
 
+NATURES = frozenset({
+    "Hardy", "Lonely", "Brave", "Adamant", "Naughty",
+    "Bold", "Docile", "Relaxed", "Impish", "Lax",
+    "Timid", "Hasty", "Serious", "Jolly", "Naive",
+    "Modest", "Mild", "Quiet", "Bashful", "Rash",
+    "Calm", "Gentle", "Sassy", "Careful", "Quirky",
+})
+
+TYPES = frozenset({
+    "Normal", "Fire", "Water", "Electric", "Grass", "Ice",
+    "Fighting", "Poison", "Ground", "Flying", "Psychic", "Bug",
+    "Rock", "Ghost", "Dragon", "Dark", "Steel", "Fairy",
+})
+
 DexLookup = dict[str, dict[str, list[str]]]  # name_casefold -> {"abilities": [...], "moves": [...]}
 
 
@@ -75,6 +89,18 @@ def _check_ability_and_moves(
     return soft
 
 
+def _check_vocab_and_moves(poke: ChampionsTeamPokemon) -> list[str]:
+    soft: list[str] = []
+    if poke.nature is not None and poke.nature not in NATURES:
+        soft.append("nature_unknown")
+    if poke.tera_type is not None and poke.tera_type not in TYPES:
+        soft.append("tera_type_unknown")
+    moves = [m for m in (poke.move1, poke.move2, poke.move3, poke.move4) if m]
+    if not (1 <= len(moves) <= 4):
+        soft.append("move_count")
+    return soft
+
+
 def validate(
     draft: ChampionsTeamDraft,
     *,
@@ -95,6 +121,9 @@ def validate(
             if code not in hard:
                 hard.append(code)
         for code in _check_ability_and_moves(poke, dex_lookup):
+            if code not in soft:
+                soft.append(code)
+        for code in _check_vocab_and_moves(poke):
             if code not in soft:
                 soft.append(code)
 

--- a/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
@@ -45,8 +45,41 @@ def _check_team_shape(pokes: list[ChampionsTeamPokemon]) -> list[str]:
     return reasons
 
 
-def validate(draft: ChampionsTeamDraft) -> ValidationReport:
-    """Validate a team draft. Returns a ValidationReport."""
+DexLookup = dict[str, dict[str, list[str]]]  # name_casefold -> {"abilities": [...], "moves": [...]}
+
+
+def _check_pokemon_identity(poke: ChampionsTeamPokemon, dex: DexLookup | None) -> list[str]:
+    if dex is None:
+        return []
+    if poke.pokemon.casefold() not in dex:
+        return ["pokemon_unknown"]
+    return []
+
+
+def _check_ability_and_moves(
+    poke: ChampionsTeamPokemon, dex: DexLookup | None
+) -> list[str]:
+    if dex is None:
+        return []
+    entry = dex.get(poke.pokemon.casefold())
+    if entry is None:
+        return []
+    soft: list[str] = []
+    if poke.ability and poke.ability not in entry["abilities"]:
+        soft.append("ability_illegal")
+    moves = [poke.move1, poke.move2, poke.move3, poke.move4]
+    for move in moves:
+        if move and move not in entry["moves"]:
+            soft.append("move_illegal")
+            break
+    return soft
+
+
+def validate(
+    draft: ChampionsTeamDraft,
+    *,
+    dex_lookup: DexLookup | None = None,
+) -> ValidationReport:
     hard: list[str] = []
     soft: list[str] = []
 
@@ -58,6 +91,12 @@ def validate(draft: ChampionsTeamDraft) -> ValidationReport:
         for code in _check_sp_numeric(poke):
             if code not in hard:
                 hard.append(code)
+        for code in _check_pokemon_identity(poke, dex_lookup):
+            if code not in hard:
+                hard.append(code)
+        for code in _check_ability_and_moves(poke, dex_lookup):
+            if code not in soft:
+                soft.append(code)
 
     return ValidationReport(
         passed=not hard,

--- a/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
@@ -6,7 +6,7 @@ Emits a ValidationReport with hard/soft failure reason codes.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
 
@@ -17,9 +17,8 @@ SP_TOTAL_MAX = 66
 @dataclass(frozen=True)
 class ValidationReport:
     passed: bool
-    hard_failures: list[str] = field(default_factory=list)
-    soft_failures: list[str] = field(default_factory=list)
-    normalizations: list[str] = field(default_factory=list)
+    hard_failures: tuple[str, ...] = ()
+    soft_failures: tuple[str, ...] = ()
 
 
 def _check_sp_numeric(poke: ChampionsTeamPokemon) -> list[str]:
@@ -122,7 +121,6 @@ def _check_ability_and_moves(poke: ChampionsTeamPokemon, dex: DexLookup | None) 
     for move in moves:
         if move and move not in entry["moves"]:
             soft.append("move_illegal")
-            break
     return soft
 
 
@@ -166,6 +164,6 @@ def validate(
 
     return ValidationReport(
         passed=not hard,
-        hard_failures=hard,
-        soft_failures=soft,
+        hard_failures=tuple(hard),
+        soft_failures=tuple(soft),
     )

--- a/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
@@ -141,6 +141,15 @@ def validate(
     *,
     dex_lookup: DexLookup | None = None,
 ) -> ValidationReport:
+    """Validate a draft. Returns hard (reject) and soft (warn) reason codes.
+
+    When ``dex_lookup`` is ``None`` the species-legality
+    (``pokemon_unknown``) and ability/move-legality
+    (``ability_illegal`` / ``move_illegal``) checks are skipped — the
+    caller is responsible for supplying a dex when those checks are
+    desired. SP numeric, team-shape, and nature/tera vocab checks
+    always run.
+    """
     hard: list[str] = []
     soft: list[str] = []
 

--- a/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
+++ b/src/smogon_vgc_mcp/fetcher/ingestion/validator.py
@@ -1,0 +1,52 @@
+"""Deterministic validator for Champions team drafts.
+
+Runs on every extracted team. Pure functions — no network, no LLM.
+Emits a ValidationReport with hard/soft failure reason codes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
+
+SP_PER_STAT_MAX = 32
+SP_TOTAL_MAX = 66
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    passed: bool
+    hard_failures: list[str] = field(default_factory=list)
+    soft_failures: list[str] = field(default_factory=list)
+    normalizations: list[str] = field(default_factory=list)
+
+
+def _check_sp_numeric(poke: ChampionsTeamPokemon) -> list[str]:
+    """Return list of reason codes for this Pokemon's SP values."""
+    sp_values = [poke.sp_hp, poke.sp_atk, poke.sp_def, poke.sp_spa, poke.sp_spd, poke.sp_spe]
+    reasons: list[str] = []
+    if any(v < 0 for v in sp_values):
+        reasons.append("sp_negative")
+    if any(v > SP_PER_STAT_MAX for v in sp_values):
+        reasons.append("sp_over_per_stat")
+    if sum(sp_values) > SP_TOTAL_MAX:
+        reasons.append("sp_over_total")
+    return reasons
+
+
+def validate(draft: ChampionsTeamDraft) -> ValidationReport:
+    """Validate a team draft. Returns a ValidationReport."""
+    hard: list[str] = []
+    soft: list[str] = []
+
+    for poke in draft.pokemon:
+        for code in _check_sp_numeric(poke):
+            if code not in hard:
+                hard.append(code)
+
+    return ValidationReport(
+        passed=not hard,
+        hard_failures=hard,
+        soft_failures=soft,
+    )

--- a/src/smogon_vgc_mcp/fetcher/sheets.py
+++ b/src/smogon_vgc_mcp/fetcher/sheets.py
@@ -298,6 +298,7 @@ def _empty_counts() -> dict[str, int]:
         "fetch_failed": 0,
         "parse_failed": 0,
         "db_error": 0,
+        "unexpected_error": 0,
     }
 
 
@@ -342,14 +343,14 @@ async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
         except Exception as exc:
             # Covers normalizer/validator crashes the pipeline didn't
             # already catch (DB-write failures are caught in ingest_url
-            # and returned as status=db_error). Bucket unknowns as
-            # fetch_failed but include the exception type so the log is
-            # diagnosable.
+            # and returned as status=db_error). Bucket separately from
+            # fetch_failed so operators can distinguish network issues
+            # from code bugs.
             logger.exception(
                 "ingest_champions_sheet: unhandled %s for url=%s",
                 type(exc).__name__,
                 url,
             )
-            counts["fetch_failed"] = counts.get("fetch_failed", 0) + 1
+            counts["unexpected_error"] = counts.get("unexpected_error", 0) + 1
 
     return counts

--- a/src/smogon_vgc_mcp/fetcher/sheets.py
+++ b/src/smogon_vgc_mcp/fetcher/sheets.py
@@ -303,6 +303,11 @@ async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
 
     fetched = await fetch_text_resilient(sheet_url, service="sheets")
     if not fetched.success or not fetched.data:
+        logger.error(
+            "ingest_champions_sheet: failed to fetch sheet sheet_url=%s error=%s",
+            sheet_url,
+            fetched.error,
+        )
         return {"auto": 0, "review_pending": 0, "rejected": 0, "fetch_failed": 1, "parse_failed": 0}
 
     reader = csv.reader(io.StringIO(fetched.data))
@@ -323,8 +328,8 @@ async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
         try:
             result = await ingest_url(url, db_path=db_path)
             counts[result.status] = counts.get(result.status, 0) + 1
-        except Exception as exc:
-            logger.error("ingest_champions_sheet: unhandled error for url=%s: %s", url, exc)
+        except Exception:
+            logger.exception("ingest_champions_sheet: unhandled error for url=%s", url)
             counts["fetch_failed"] = counts.get("fetch_failed", 0) + 1
 
     return counts

--- a/src/smogon_vgc_mcp/fetcher/sheets.py
+++ b/src/smogon_vgc_mcp/fetcher/sheets.py
@@ -328,8 +328,15 @@ async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
         try:
             result = await ingest_url(url, db_path=db_path)
             counts[result.status] = counts.get(result.status, 0) + 1
-        except Exception:
-            logger.exception("ingest_champions_sheet: unhandled error for url=%s", url)
+        except Exception as exc:
+            # Covers normalizer/validator/DB-write crashes the pipeline
+            # didn't already catch. Bucket as fetch_failed but include
+            # the exception type so the log is diagnosable.
+            logger.exception(
+                "ingest_champions_sheet: unhandled %s for url=%s",
+                type(exc).__name__,
+                url,
+            )
             counts["fetch_failed"] = counts.get("fetch_failed", 0) + 1
 
     return counts

--- a/src/smogon_vgc_mcp/fetcher/sheets.py
+++ b/src/smogon_vgc_mcp/fetcher/sheets.py
@@ -5,10 +5,12 @@ import csv
 import io
 import logging
 import re
+from pathlib import Path
 
 import aiosqlite
 
 from smogon_vgc_mcp.database.schema import get_connection, get_db_path, init_database
+from smogon_vgc_mcp.fetcher.ingestion.pipeline import ingest_url
 from smogon_vgc_mcp.fetcher.pokepaste import fetch_pokepaste, parse_pokepaste
 from smogon_vgc_mcp.formats import DEFAULT_FORMAT, get_format, get_sheet_csv_url
 from smogon_vgc_mcp.resilience import (
@@ -286,3 +288,37 @@ async def fetch_and_store_pokepaste_teams(
         "skipped_details": skipped[:10],
         "circuit_states": get_all_circuit_states(),
     }
+
+
+async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
+    """Read the Champions Google Sheet tab and ingest each row's URL.
+
+    Returns a counter dict of status -> count.
+    """
+    sheet_url = get_sheet_csv_url("champions_ma")
+    if not sheet_url:
+        return {"auto": 0, "review_pending": 0, "rejected": 0, "fetch_failed": 0, "parse_failed": 0}
+
+    fetched = await fetch_text_resilient(sheet_url, service="sheets")
+    if not fetched.success or not fetched.data:
+        return {"auto": 0, "review_pending": 0, "rejected": 0, "fetch_failed": 1, "parse_failed": 0}
+
+    reader = csv.reader(io.StringIO(fetched.data))
+    rows = list(reader)
+
+    counts: dict[str, int] = {
+        "auto": 0,
+        "review_pending": 0,
+        "rejected": 0,
+        "fetch_failed": 0,
+        "parse_failed": 0,
+    }
+
+    for row in rows[1:]:  # skip header
+        url = next((c for c in row if c.startswith(("http://", "https://"))), "")
+        if not url:
+            continue
+        result = await ingest_url(url, db_path=db_path)
+        counts[result.status] = counts.get(result.status, 0) + 1
+
+    return counts

--- a/src/smogon_vgc_mcp/fetcher/sheets.py
+++ b/src/smogon_vgc_mcp/fetcher/sheets.py
@@ -295,8 +295,10 @@ async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
 
     Returns a counter dict of status -> count.
     """
+    await init_database(db_path)
     sheet_url = get_sheet_csv_url("champions_ma")
     if not sheet_url:
+        logger.error("ingest_champions_sheet: no sheet_gid configured for champions_ma")
         return {"auto": 0, "review_pending": 0, "rejected": 0, "fetch_failed": 0, "parse_failed": 0}
 
     fetched = await fetch_text_resilient(sheet_url, service="sheets")
@@ -314,11 +316,15 @@ async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
         "parse_failed": 0,
     }
 
-    for row in rows[1:]:  # skip header
+    for row in rows[1:]:
         url = next((c for c in row if c.startswith(("http://", "https://"))), "")
         if not url:
             continue
-        result = await ingest_url(url, db_path=db_path)
-        counts[result.status] = counts.get(result.status, 0) + 1
+        try:
+            result = await ingest_url(url, db_path=db_path)
+            counts[result.status] = counts.get(result.status, 0) + 1
+        except Exception as exc:
+            logger.error("ingest_champions_sheet: unhandled error for url=%s: %s", url, exc)
+            counts["fetch_failed"] = counts.get("fetch_failed", 0) + 1
 
     return counts

--- a/src/smogon_vgc_mcp/fetcher/sheets.py
+++ b/src/smogon_vgc_mcp/fetcher/sheets.py
@@ -345,12 +345,13 @@ async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
         try:
             result = await ingest_url(url, db_path=db_path, dex_lookup=dex_lookup, skip_init=True)
             counts[result.status] = counts.get(result.status, 0) + 1
-        except Exception as exc:
-            # Covers normalizer/validator crashes the pipeline didn't
-            # already catch (DB-write failures are caught in ingest_url
-            # and returned as status=db_error). Bucket separately from
-            # fetch_failed so operators can distinguish network issues
-            # from code bugs.
+        except (aiosqlite.Error, OSError, RuntimeError) as exc:
+            # Narrow catch: genuine DB/disk/runtime failures on a single
+            # row shouldn't abort the whole sheet. Programmer bugs
+            # (TypeError, AttributeError, KeyError, etc.) are NOT caught
+            # here — they surface as real crashes so regressions in the
+            # normalizer/validator/parser are immediately visible rather
+            # than silently inflating an ``unexpected_error`` counter.
             logger.exception(
                 "ingest_champions_sheet: unhandled %s for url=%s",
                 type(exc).__name__,

--- a/src/smogon_vgc_mcp/fetcher/sheets.py
+++ b/src/smogon_vgc_mcp/fetcher/sheets.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import aiosqlite
 
 from smogon_vgc_mcp.database.schema import get_connection, get_db_path, init_database
-from smogon_vgc_mcp.fetcher.ingestion.pipeline import ingest_url
+from smogon_vgc_mcp.fetcher.ingestion.pipeline import ingest_url, load_dex_lookup
 from smogon_vgc_mcp.fetcher.pokepaste import fetch_pokepaste, parse_pokepaste
 from smogon_vgc_mcp.formats import DEFAULT_FORMAT, get_format, get_sheet_csv_url
 from smogon_vgc_mcp.resilience import (
@@ -306,8 +306,6 @@ async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
 
     Returns a counter dict of status -> count.
     """
-    from smogon_vgc_mcp.fetcher.ingestion.pipeline import load_dex_lookup
-
     await init_database(db_path)
     sheet_url = get_sheet_csv_url("champions_ma")
     if not sheet_url:

--- a/src/smogon_vgc_mcp/fetcher/sheets.py
+++ b/src/smogon_vgc_mcp/fetcher/sheets.py
@@ -290,16 +290,29 @@ async def fetch_and_store_pokepaste_teams(
     }
 
 
+def _empty_counts() -> dict[str, int]:
+    return {
+        "auto": 0,
+        "review_pending": 0,
+        "rejected": 0,
+        "fetch_failed": 0,
+        "parse_failed": 0,
+        "db_error": 0,
+    }
+
+
 async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
     """Read the Champions Google Sheet tab and ingest each row's URL.
 
     Returns a counter dict of status -> count.
     """
+    from smogon_vgc_mcp.fetcher.ingestion.pipeline import load_dex_lookup
+
     await init_database(db_path)
     sheet_url = get_sheet_csv_url("champions_ma")
     if not sheet_url:
         logger.error("ingest_champions_sheet: no sheet_gid configured for champions_ma")
-        return {"auto": 0, "review_pending": 0, "rejected": 0, "fetch_failed": 0, "parse_failed": 0}
+        return _empty_counts()
 
     fetched = await fetch_text_resilient(sheet_url, service="sheets")
     if not fetched.success or not fetched.data:
@@ -308,30 +321,32 @@ async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
             sheet_url,
             fetched.error,
         )
-        return {"auto": 0, "review_pending": 0, "rejected": 0, "fetch_failed": 1, "parse_failed": 0}
+        counts = _empty_counts()
+        counts["fetch_failed"] = 1
+        return counts
 
     reader = csv.reader(io.StringIO(fetched.data))
     rows = list(reader)
 
-    counts: dict[str, int] = {
-        "auto": 0,
-        "review_pending": 0,
-        "rejected": 0,
-        "fetch_failed": 0,
-        "parse_failed": 0,
-    }
+    # Load the dex once for the whole run — avoids N redundant queries
+    # across a sheet of hundreds of URLs. Falls through to None (skip
+    # identity/legality checks) when the dex tables are empty.
+    dex_lookup = await load_dex_lookup(db_path)
 
+    counts = _empty_counts()
     for row in rows[1:]:
         url = next((c for c in row if c.startswith(("http://", "https://"))), "")
         if not url:
             continue
         try:
-            result = await ingest_url(url, db_path=db_path)
+            result = await ingest_url(url, db_path=db_path, dex_lookup=dex_lookup)
             counts[result.status] = counts.get(result.status, 0) + 1
         except Exception as exc:
-            # Covers normalizer/validator/DB-write crashes the pipeline
-            # didn't already catch. Bucket as fetch_failed but include
-            # the exception type so the log is diagnosable.
+            # Covers normalizer/validator crashes the pipeline didn't
+            # already catch (DB-write failures are caught in ingest_url
+            # and returned as status=db_error). Bucket unknowns as
+            # fetch_failed but include the exception type so the log is
+            # diagnosable.
             logger.exception(
                 "ingest_champions_sheet: unhandled %s for url=%s",
                 type(exc).__name__,

--- a/src/smogon_vgc_mcp/fetcher/sheets.py
+++ b/src/smogon_vgc_mcp/fetcher/sheets.py
@@ -310,8 +310,13 @@ async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
     await init_database(db_path)
     sheet_url = get_sheet_csv_url("champions_ma")
     if not sheet_url:
+        # Signal config drift via fetch_failed so callers comparing
+        # counters against zero can't mistake a missing sheet_gid for a
+        # successful run over an empty sheet.
         logger.error("ingest_champions_sheet: no sheet_gid configured for champions_ma")
-        return _empty_counts()
+        counts = _empty_counts()
+        counts["fetch_failed"] = 1
+        return counts
 
     fetched = await fetch_text_resilient(sheet_url, service="sheets")
     if not fetched.success or not fetched.data:
@@ -338,7 +343,7 @@ async def ingest_champions_sheet(db_path: Path | None = None) -> dict[str, int]:
         if not url:
             continue
         try:
-            result = await ingest_url(url, db_path=db_path, dex_lookup=dex_lookup)
+            result = await ingest_url(url, db_path=db_path, dex_lookup=dex_lookup, skip_init=True)
             counts[result.status] = counts.get(result.status, 0) + 1
         except Exception as exc:
             # Covers normalizer/validator crashes the pipeline didn't

--- a/src/smogon_vgc_mcp/formats.py
+++ b/src/smogon_vgc_mcp/formats.py
@@ -126,6 +126,9 @@ FORMATS: dict[str, FormatConfig] = {
         available_months=[],
         generation=7,
         smogon_stats_available=False,
+        # Date range intentionally starts Sept 2016 (Sun/Moon release
+        # window) even though the code year is 2017 — the competitive
+        # VGC17 season opened before calendar 2017.
         date_range=("2016-09-01", "2017-12-31"),
         is_historical=True,
     ),

--- a/src/smogon_vgc_mcp/formats.py
+++ b/src/smogon_vgc_mcp/formats.py
@@ -64,6 +64,7 @@ FORMATS: dict[str, FormatConfig] = {
         stat_system="champions_sp",
         calc_backend="python_native",
         smogon_stats_available=False,
+        sheet_gid="791705272",
         is_current=False,
     ),
     # Historical archives — Nugget Bridge corpus (2012-2017). No live stats,

--- a/tests/fixtures/champions_pokepaste_sample.txt
+++ b/tests/fixtures/champions_pokepaste_sample.txt
@@ -1,0 +1,21 @@
+Koraidon @ Life Orb
+Ability: Orichalcum Pulse
+Level: 50
+Tera Type: Fire
+EVs: 32 Atk / 32 Spe
+Adamant Nature
+- Flare Blitz
+- Collision Course
+- Protect
+- Dragon Claw
+
+Flutter Mane @ Focus Sash
+Ability: Protosynthesis
+Level: 50
+Tera Type: Fairy
+EVs: 32 SpA / 32 Spe
+Timid Nature
+- Moonblast
+- Shadow Ball
+- Protect
+- Dazzling Gleam

--- a/tests/test_champions_team_queries.py
+++ b/tests/test_champions_team_queries.py
@@ -1,0 +1,108 @@
+import json
+from pathlib import Path
+
+import pytest
+from smogon_vgc_mcp.database.champions_team_queries import (
+    compute_team_fingerprint,
+    get_champions_team,
+    write_or_queue_team,
+)
+from smogon_vgc_mcp.database.models import ChampionsTeam, ChampionsTeamPokemon
+from smogon_vgc_mcp.database.schema import get_connection, init_database
+
+
+@pytest.fixture
+async def db_path(tmp_path: Path):
+    p = tmp_path / "test.db"
+    await init_database(p)
+    return p
+
+
+def _team(
+    *pokes: ChampionsTeamPokemon,
+    status: str = "auto",
+    conf: float = 1.0,
+    fingerprint: str = "abc123",
+) -> ChampionsTeam:
+    return ChampionsTeam(
+        team_id=fingerprint,
+        source_type="pokepaste",
+        source_url="https://pokepast.es/abc",
+        ingestion_status=status,
+        confidence_score=conf,
+        pokemon=list(pokes),
+    )
+
+
+async def test_write_auto_team(db_path: Path):
+    team = _team(
+        ChampionsTeamPokemon(slot=1, pokemon="Koraidon", sp_atk=32, sp_spe=32),
+        fingerprint="fp1",
+    )
+    async with get_connection(db_path) as db:
+        row_id = await write_or_queue_team(db, team)
+        assert row_id > 0
+        out = await get_champions_team(db, row_id)
+    assert out is not None
+    assert out.ingestion_status == "auto"
+    assert len(out.pokemon) == 1
+    assert out.pokemon[0].pokemon == "Koraidon"
+
+
+async def test_write_queue_team(db_path: Path):
+    team = _team(
+        ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"),
+        status="review_pending",
+        conf=0.5,
+        fingerprint="fp2",
+    )
+    async with get_connection(db_path) as db:
+        row_id = await write_or_queue_team(db, team)
+        out = await get_champions_team(db, row_id)
+    assert out.ingestion_status == "review_pending"
+    assert out.confidence_score == pytest.approx(0.5)
+
+
+async def test_duplicate_fingerprint_returns_existing(db_path: Path):
+    team = _team(
+        ChampionsTeamPokemon(slot=1, pokemon="Koraidon"),
+        fingerprint="dup",
+    )
+    async with get_connection(db_path) as db:
+        id1 = await write_or_queue_team(db, team)
+        id2 = await write_or_queue_team(db, team)
+    assert id1 == id2
+
+
+async def test_review_reasons_persisted(db_path: Path):
+    team = _team(
+        ChampionsTeamPokemon(slot=1, pokemon="X"),
+        fingerprint="rr",
+    )
+    team.review_reasons = ["sp_over_total"]
+    team.normalizations = ["move_fuzzy:Close Combatt->Close Combat"]
+    async with get_connection(db_path) as db:
+        row_id = await write_or_queue_team(db, team)
+        out = await get_champions_team(db, row_id)
+    assert out.review_reasons == ["sp_over_total"]
+    assert out.normalizations == ["move_fuzzy:Close Combatt->Close Combat"]
+
+
+def test_fingerprint_stable_for_same_team():
+    team_a = _team(ChampionsTeamPokemon(slot=1, pokemon="Koraidon", move1="Flare Blitz"))
+    team_b = _team(ChampionsTeamPokemon(slot=1, pokemon="Koraidon", move1="Flare Blitz"))
+    assert compute_team_fingerprint(team_a.pokemon) == compute_team_fingerprint(team_b.pokemon)
+
+
+def test_fingerprint_move_order_insensitive():
+    team_a = _team(ChampionsTeamPokemon(
+        slot=1, pokemon="X", move1="A", move2="B", move3="C", move4="D"))
+    team_b = _team(ChampionsTeamPokemon(
+        slot=1, pokemon="X", move1="D", move2="C", move3="B", move4="A"))
+    assert compute_team_fingerprint(team_a.pokemon) == compute_team_fingerprint(team_b.pokemon)
+
+
+def test_fingerprint_different_when_sets_differ():
+    team_a = _team(ChampionsTeamPokemon(slot=1, pokemon="Koraidon"))
+    team_b = _team(ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"))
+    assert compute_team_fingerprint(team_a.pokemon) != compute_team_fingerprint(team_b.pokemon)

--- a/tests/test_champions_team_queries.py
+++ b/tests/test_champions_team_queries.py
@@ -108,3 +108,19 @@ def test_fingerprint_different_when_sets_differ():
     team_a = _team(ChampionsTeamPokemon(slot=1, pokemon="Koraidon"))
     team_b = _team(ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"))
     assert compute_team_fingerprint(team_a.pokemon) != compute_team_fingerprint(team_b.pokemon)
+
+
+async def test_get_champions_team_returns_none_when_missing(db_path: Path):
+    async with get_connection(db_path) as db:
+        out = await get_champions_team(db, row_id=99999)
+    assert out is None
+
+
+async def test_duplicate_fingerprint_isolated_per_format(db_path: Path):
+    team_a = _team(ChampionsTeamPokemon(slot=1, pokemon="Koraidon"), fingerprint="shared_fp")
+    team_b = _team(ChampionsTeamPokemon(slot=1, pokemon="Koraidon"), fingerprint="shared_fp")
+    team_b.format = "champions_test"
+    async with get_connection(db_path) as db:
+        id_a = await write_or_queue_team(db, team_a)
+        id_b = await write_or_queue_team(db, team_b)
+    assert id_a != id_b

--- a/tests/test_champions_team_queries.py
+++ b/tests/test_champions_team_queries.py
@@ -74,6 +74,28 @@ async def test_duplicate_fingerprint_returns_existing(db_path: Path):
     assert id1 == id2
 
 
+async def test_duplicate_fingerprint_preserves_original_payload(db_path: Path):
+    # Dedup is last-write-wins-NO — on (format, team_id) collision the
+    # existing row is returned untouched. A re-ingest with corrected
+    # source_url / review_reasons MUST NOT silently overwrite the first
+    # row. Document this via test so a future "update on conflict" PR
+    # has to change the test too.
+    first = _team(ChampionsTeamPokemon(slot=1, pokemon="Koraidon"), fingerprint="same_fp")
+    first.source_url = "https://pokepast.es/original"
+    second = _team(ChampionsTeamPokemon(slot=1, pokemon="Koraidon"), fingerprint="same_fp")
+    second.source_url = "https://pokepast.es/edited"
+    second.review_reasons = ["nature_unknown"]
+
+    async with get_connection(db_path) as db:
+        id1 = await write_or_queue_team(db, first)
+        id2 = await write_or_queue_team(db, second)
+        stored = await get_champions_team(db, id1)
+    assert id1 == id2
+    assert stored is not None
+    assert stored.source_url == "https://pokepast.es/original"
+    assert stored.review_reasons is None
+
+
 async def test_review_reasons_persisted(db_path: Path):
     team = _team(
         ChampionsTeamPokemon(slot=1, pokemon="X"),

--- a/tests/test_champions_team_queries.py
+++ b/tests/test_champions_team_queries.py
@@ -1,7 +1,7 @@
-import json
 from pathlib import Path
 
 import pytest
+
 from smogon_vgc_mcp.database.champions_team_queries import (
     compute_team_fingerprint,
     get_champions_team,
@@ -95,10 +95,12 @@ def test_fingerprint_stable_for_same_team():
 
 
 def test_fingerprint_move_order_insensitive():
-    team_a = _team(ChampionsTeamPokemon(
-        slot=1, pokemon="X", move1="A", move2="B", move3="C", move4="D"))
-    team_b = _team(ChampionsTeamPokemon(
-        slot=1, pokemon="X", move1="D", move2="C", move3="B", move4="A"))
+    team_a = _team(
+        ChampionsTeamPokemon(slot=1, pokemon="X", move1="A", move2="B", move3="C", move4="D")
+    )
+    team_b = _team(
+        ChampionsTeamPokemon(slot=1, pokemon="X", move1="D", move2="C", move3="B", move4="A")
+    )
     assert compute_team_fingerprint(team_a.pokemon) == compute_team_fingerprint(team_b.pokemon)
 
 

--- a/tests/test_champions_team_queries.py
+++ b/tests/test_champions_team_queries.py
@@ -110,6 +110,14 @@ def test_fingerprint_different_when_sets_differ():
     assert compute_team_fingerprint(team_a.pokemon) != compute_team_fingerprint(team_b.pokemon)
 
 
+def test_fingerprint_slot_order_sensitive():
+    # Same species in different slots must produce different fingerprints —
+    # reassignment is a team-level change, not a reorder.
+    team_a = _team(ChampionsTeamPokemon(slot=1, pokemon="Koraidon"))
+    team_b = _team(ChampionsTeamPokemon(slot=2, pokemon="Koraidon"))
+    assert compute_team_fingerprint(team_a.pokemon) != compute_team_fingerprint(team_b.pokemon)
+
+
 async def test_get_champions_team_returns_none_when_missing(db_path: Path):
     async with get_connection(db_path) as db:
         out = await get_champions_team(db, row_id=99999)

--- a/tests/test_champions_team_schema.py
+++ b/tests/test_champions_team_schema.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 from smogon_vgc_mcp.database.schema import get_connection, init_database
 
 
@@ -16,9 +17,18 @@ async def test_champions_teams_table_created(db):
     async with db.execute("PRAGMA table_info(champions_teams)") as cur:
         cols = {row[1] for row in await cur.fetchall()}
     assert {
-        "id", "format", "team_id", "description", "owner",
-        "source_type", "source_url", "ingestion_status",
-        "confidence_score", "review_reasons", "normalizations", "ingested_at",
+        "id",
+        "format",
+        "team_id",
+        "description",
+        "owner",
+        "source_type",
+        "source_url",
+        "ingestion_status",
+        "confidence_score",
+        "review_reasons",
+        "normalizations",
+        "ingested_at",
     } <= cols
 
 
@@ -26,10 +36,25 @@ async def test_champions_team_pokemon_table_created(db):
     async with db.execute("PRAGMA table_info(champions_team_pokemon)") as cur:
         cols = {row[1] for row in await cur.fetchall()}
     assert {
-        "id", "team_id", "slot", "pokemon", "item", "ability", "nature",
-        "tera_type", "level",
-        "sp_hp", "sp_atk", "sp_def", "sp_spa", "sp_spd", "sp_spe",
-        "move1", "move2", "move3", "move4",
+        "id",
+        "team_id",
+        "slot",
+        "pokemon",
+        "item",
+        "ability",
+        "nature",
+        "tera_type",
+        "level",
+        "sp_hp",
+        "sp_atk",
+        "sp_def",
+        "sp_spa",
+        "sp_spd",
+        "sp_spe",
+        "move1",
+        "move2",
+        "move3",
+        "move4",
     } <= cols
 
 

--- a/tests/test_champions_team_schema.py
+++ b/tests/test_champions_team_schema.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+from smogon_vgc_mcp.database.schema import get_connection, init_database
+
+
+@pytest.fixture
+async def db(tmp_path: Path):
+    db_path = tmp_path / "test.db"
+    await init_database(db_path)
+    async with get_connection(db_path) as conn:
+        yield conn
+
+
+async def test_champions_teams_table_created(db):
+    async with db.execute("PRAGMA table_info(champions_teams)") as cur:
+        cols = {row[1] for row in await cur.fetchall()}
+    assert {
+        "id", "format", "team_id", "description", "owner",
+        "source_type", "source_url", "ingestion_status",
+        "confidence_score", "review_reasons", "normalizations", "ingested_at",
+    } <= cols
+
+
+async def test_champions_team_pokemon_table_created(db):
+    async with db.execute("PRAGMA table_info(champions_team_pokemon)") as cur:
+        cols = {row[1] for row in await cur.fetchall()}
+    assert {
+        "id", "team_id", "slot", "pokemon", "item", "ability", "nature",
+        "tera_type", "level",
+        "sp_hp", "sp_atk", "sp_def", "sp_spa", "sp_spd", "sp_spe",
+        "move1", "move2", "move3", "move4",
+    } <= cols
+
+
+async def test_sp_constraints_enforced(db):
+    await db.execute(
+        "INSERT INTO champions_teams(format, team_id, source_type, source_url, "
+        "ingestion_status, confidence_score) VALUES "
+        "('champions_ma', 't1', 'pokepaste', 'https://x', 'auto', 1.0)"
+    )
+    # Per-stat > 32 must fail
+    with pytest.raises(Exception):
+        await db.execute(
+            "INSERT INTO champions_team_pokemon(team_id, slot, pokemon, sp_hp) "
+            "VALUES (1, 1, 'Flutter Mane', 33)"
+        )
+
+
+async def test_sp_total_constraint_enforced(db):
+    await db.execute(
+        "INSERT INTO champions_teams(format, team_id, source_type, source_url, "
+        "ingestion_status, confidence_score) VALUES "
+        "('champions_ma', 't2', 'pokepaste', 'https://x', 'auto', 1.0)"
+    )
+    # Sum > 66 must fail: 32 + 32 + 10 = 74
+    with pytest.raises(Exception):
+        await db.execute(
+            "INSERT INTO champions_team_pokemon(team_id, slot, pokemon, "
+            "sp_hp, sp_atk, sp_def) VALUES (1, 1, 'Koraidon', 32, 32, 10)"
+        )

--- a/tests/test_champions_team_schema.py
+++ b/tests/test_champions_team_schema.py
@@ -84,3 +84,27 @@ async def test_sp_total_constraint_enforced(db):
             "INSERT INTO champions_team_pokemon(team_id, slot, pokemon, "
             "sp_hp, sp_atk, sp_def) VALUES (1, 1, 'Koraidon', 32, 32, 10)"
         )
+
+
+async def test_slot_constraint_enforced_low(db):
+    await db.execute(
+        "INSERT INTO champions_teams(format, team_id, source_type, source_url, "
+        "ingestion_status, confidence_score) VALUES "
+        "('champions_ma', 't3', 'pokepaste', 'https://x', 'auto', 1.0)"
+    )
+    with pytest.raises(Exception):
+        await db.execute(
+            "INSERT INTO champions_team_pokemon(team_id, slot, pokemon) VALUES (1, 0, 'Koraidon')"
+        )
+
+
+async def test_slot_constraint_enforced_high(db):
+    await db.execute(
+        "INSERT INTO champions_teams(format, team_id, source_type, source_url, "
+        "ingestion_status, confidence_score) VALUES "
+        "('champions_ma', 't4', 'pokepaste', 'https://x', 'auto', 1.0)"
+    )
+    with pytest.raises(Exception):
+        await db.execute(
+            "INSERT INTO champions_team_pokemon(team_id, slot, pokemon) VALUES (1, 7, 'Koraidon')"
+        )

--- a/tests/test_ingestion_classifier.py
+++ b/tests/test_ingestion_classifier.py
@@ -1,20 +1,24 @@
 import pytest
+
 from smogon_vgc_mcp.fetcher.ingestion.classifier import Tier, classify_url
 
 
-@pytest.mark.parametrize("url, tier", [
-    ("https://pokepast.es/abc123", Tier.POKEPASTE),
-    ("http://pokepast.es/abc123", Tier.POKEPASTE),
-    ("https://pokepast.es/abc123/raw", Tier.POKEPASTE),
-    ("https://twitter.com/user/status/12345", Tier.X),
-    ("https://x.com/user/status/12345", Tier.X),
-    ("https://mobile.twitter.com/user/status/12345", Tier.X),
-    ("https://nuggetbridge.com/2016/01/foo", Tier.BLOG),
-    ("https://smogon.com/forums/threads/x.12345/", Tier.BLOG),
-    ("https://medium.com/@user/my-team", Tier.BLOG),
-    ("", Tier.UNKNOWN),
-    ("not-a-url", Tier.UNKNOWN),
-    ("ftp://example.com/file", Tier.UNKNOWN),
-])
+@pytest.mark.parametrize(
+    "url, tier",
+    [
+        ("https://pokepast.es/abc123", Tier.POKEPASTE),
+        ("http://pokepast.es/abc123", Tier.POKEPASTE),
+        ("https://pokepast.es/abc123/raw", Tier.POKEPASTE),
+        ("https://twitter.com/user/status/12345", Tier.X),
+        ("https://x.com/user/status/12345", Tier.X),
+        ("https://mobile.twitter.com/user/status/12345", Tier.X),
+        ("https://nuggetbridge.com/2016/01/foo", Tier.BLOG),
+        ("https://smogon.com/forums/threads/x.12345/", Tier.BLOG),
+        ("https://medium.com/@user/my-team", Tier.BLOG),
+        ("", Tier.UNKNOWN),
+        ("not-a-url", Tier.UNKNOWN),
+        ("ftp://example.com/file", Tier.UNKNOWN),
+    ],
+)
 def test_classify_url(url: str, tier: Tier):
     assert classify_url(url) == tier

--- a/tests/test_ingestion_classifier.py
+++ b/tests/test_ingestion_classifier.py
@@ -9,6 +9,7 @@ from smogon_vgc_mcp.fetcher.ingestion.classifier import Tier, classify_url
         ("https://pokepast.es/abc123", Tier.POKEPASTE),
         ("http://pokepast.es/abc123", Tier.POKEPASTE),
         ("https://pokepast.es/abc123/raw", Tier.POKEPASTE),
+        ("https://www.pokepast.es/abc123", Tier.POKEPASTE),
         ("https://twitter.com/user/status/12345", Tier.X),
         ("https://x.com/user/status/12345", Tier.X),
         ("https://mobile.twitter.com/user/status/12345", Tier.X),

--- a/tests/test_ingestion_classifier.py
+++ b/tests/test_ingestion_classifier.py
@@ -1,0 +1,20 @@
+import pytest
+from smogon_vgc_mcp.fetcher.ingestion.classifier import Tier, classify_url
+
+
+@pytest.mark.parametrize("url, tier", [
+    ("https://pokepast.es/abc123", Tier.POKEPASTE),
+    ("http://pokepast.es/abc123", Tier.POKEPASTE),
+    ("https://pokepast.es/abc123/raw", Tier.POKEPASTE),
+    ("https://twitter.com/user/status/12345", Tier.X),
+    ("https://x.com/user/status/12345", Tier.X),
+    ("https://mobile.twitter.com/user/status/12345", Tier.X),
+    ("https://nuggetbridge.com/2016/01/foo", Tier.BLOG),
+    ("https://smogon.com/forums/threads/x.12345/", Tier.BLOG),
+    ("https://medium.com/@user/my-team", Tier.BLOG),
+    ("", Tier.UNKNOWN),
+    ("not-a-url", Tier.UNKNOWN),
+    ("ftp://example.com/file", Tier.UNKNOWN),
+])
+def test_classify_url(url: str, tier: Tier):
+    assert classify_url(url) == tier

--- a/tests/test_ingestion_cli.py
+++ b/tests/test_ingestion_cli.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from smogon_vgc_mcp.database.schema import init_database
+from smogon_vgc_mcp.entry.ingest_cli import main_async
+from smogon_vgc_mcp.resilience import FetchResult
+
+
+@pytest.fixture
+async def db_path(tmp_path: Path):
+    p = tmp_path / "test.db"
+    await init_database(p)
+    return p
+
+
+async def test_cli_auto_write_exit_zero(db_path: Path, capsys):
+    pokepaste_text = (
+        "Koraidon @ Life Orb\nAbility: Orichalcum Pulse\nLevel: 50\nEVs: 32 Atk\n"
+        "Adamant Nature\n- Flare Blitz\n- Protect\n- Collision Course\n- Dragon Claw"
+    )
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.ok(pokepaste_text)),
+    ):
+        exit_code = await main_async(["https://pokepast.es/abc"], db_path=db_path)
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "auto" in captured.out.lower()
+
+
+async def test_cli_rejected_exit_nonzero(db_path: Path, capsys):
+    exit_code = await main_async(["not-a-url"], db_path=db_path)
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "rejected" in captured.out.lower()
+
+
+async def test_cli_missing_url_exit_usage(db_path: Path, capsys):
+    exit_code = await main_async([], db_path=db_path)
+    assert exit_code == 1

--- a/tests/test_ingestion_cli.py
+++ b/tests/test_ingestion_cli.py
@@ -40,3 +40,19 @@ async def test_cli_rejected_exit_nonzero(db_path: Path, capsys):
 async def test_cli_missing_url_exit_usage(db_path: Path, capsys):
     exit_code = await main_async([], db_path=db_path)
     assert exit_code == 1
+
+
+def test_main_unhandled_exception_exits_three(capsys, monkeypatch):
+    from smogon_vgc_mcp.entry import ingest_cli
+
+    async def boom(*a, **kw):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(ingest_cli, "main_async", boom)
+    monkeypatch.setattr("sys.argv", ["vgc-ingest", "https://pokepast.es/x"])
+    with pytest.raises(SystemExit) as excinfo:
+        ingest_cli.main()
+    assert excinfo.value.code == 3
+    captured = capsys.readouterr()
+    assert "kaboom" in captured.err
+    assert "RuntimeError" in captured.err  # traceback printed

--- a/tests/test_ingestion_cli.py
+++ b/tests/test_ingestion_cli.py
@@ -54,13 +54,15 @@ async def test_cli_parse_failed_exit_four(db_path: Path, capsys):
 
 async def test_cli_db_error_exit_five(db_path: Path, capsys):
     # DB write failure → db_error → exit code 5.
+    import aiosqlite
+
     pokepaste_text = (
         "Koraidon @ Life Orb\nAbility: Orichalcum Pulse\nLevel: 50\nEVs: 32 Atk\n"
         "Adamant Nature\n- Flare Blitz\n- Protect\n- Collision Course\n- Dragon Claw"
     )
 
     async def boom(db, team):
-        raise RuntimeError("disk full")
+        raise aiosqlite.OperationalError("disk full")
 
     with (
         patch(
@@ -74,6 +76,27 @@ async def test_cli_db_error_exit_five(db_path: Path, capsys):
     ):
         exit_code = await main_async(["https://pokepast.es/dbfail"], db_path=db_path)
     assert exit_code == 5
+
+
+async def test_cli_review_pending_exit_zero(db_path: Path, capsys):
+    # Two soft failures (nature + tera unknown) drop confidence below
+    # AUTO_WRITE_THRESHOLD, producing review_pending — which is still a
+    # successful persist and must map to exit 0 (same as auto). CI
+    # scripts key on exit code, so a regression that separates
+    # review_pending into nonzero would silently break dashboards.
+    text = (
+        "Koraidon @ Life Orb\nAbility: Orichalcum Pulse\nLevel: 50\n"
+        "Tera Type: Plasma\nEVs: 32 Atk\nFooNature Nature\n"
+        "- Flare Blitz\n- Protect\n- Collision Course\n- Dragon Claw"
+    )
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.ok(text)),
+    ):
+        exit_code = await main_async(["https://pokepast.es/soft"], db_path=db_path)
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "review_pending" in captured.out.lower()
 
 
 async def test_cli_fetch_failed_exit_three(db_path: Path, capsys):

--- a/tests/test_ingestion_cli.py
+++ b/tests/test_ingestion_cli.py
@@ -42,6 +42,57 @@ async def test_cli_missing_url_exit_usage(db_path: Path, capsys):
     assert exit_code == 1
 
 
+async def test_cli_parse_failed_exit_four(db_path: Path, capsys):
+    # Empty pokepaste body → parse_failed → exit code 4.
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.ok("")),
+    ):
+        exit_code = await main_async(["https://pokepast.es/empty"], db_path=db_path)
+    assert exit_code == 4
+
+
+async def test_cli_db_error_exit_five(db_path: Path, capsys):
+    # DB write failure → db_error → exit code 5.
+    pokepaste_text = (
+        "Koraidon @ Life Orb\nAbility: Orichalcum Pulse\nLevel: 50\nEVs: 32 Atk\n"
+        "Adamant Nature\n- Flare Blitz\n- Protect\n- Collision Course\n- Dragon Claw"
+    )
+
+    async def boom(db, team):
+        raise RuntimeError("disk full")
+
+    with (
+        patch(
+            "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+            new=AsyncMock(return_value=FetchResult.ok(pokepaste_text)),
+        ),
+        patch(
+            "smogon_vgc_mcp.fetcher.ingestion.pipeline.write_or_queue_team",
+            new=boom,
+        ),
+    ):
+        exit_code = await main_async(["https://pokepast.es/dbfail"], db_path=db_path)
+    assert exit_code == 5
+
+
+async def test_cli_fetch_failed_exit_three(db_path: Path, capsys):
+    from smogon_vgc_mcp.resilience import ErrorCategory, ServiceError
+
+    err = ServiceError(
+        category=ErrorCategory.HTTP_CLIENT_ERROR,
+        service="pokepaste",
+        message="404",
+        is_recoverable=False,
+    )
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.fail(err)),
+    ):
+        exit_code = await main_async(["https://pokepast.es/missing"], db_path=db_path)
+    assert exit_code == 3
+
+
 def test_main_unhandled_exception_exits_three(capsys, monkeypatch):
     from smogon_vgc_mcp.entry import ingest_cli
 

--- a/tests/test_ingestion_normalizer.py
+++ b/tests/test_ingestion_normalizer.py
@@ -48,3 +48,40 @@ def test_item_strip_consumed():
     d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", item="Focus Sash (consumed)"))
     normed, log = normalize(d)
     assert normed.pokemon[0].item == "Focus Sash"
+
+
+def test_item_strip_consumed_uppercase():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", item="Focus Sash (CONSUMED)"))
+    normed, log = normalize(d)
+    assert normed.pokemon[0].item == "Focus Sash"
+    assert any("item_strip_consumed" in entry for entry in log)
+
+
+def test_item_strip_consumed_titlecase():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", item="Focus Sash (Consumed)"))
+    normed, log = normalize(d)
+    assert normed.pokemon[0].item == "Focus Sash"
+    assert any("item_strip_consumed" in entry for entry in log)
+
+
+def test_move_fuzzy_match_distance_1():
+    # Single-character typo — should be corrected.
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", move1="Protct"))
+    normed, log = normalize(d, known_moves={"Protect"})
+    assert normed.pokemon[0].move1 == "Protect"
+    assert any("move_fuzzy" in entry for entry in log)
+
+
+def test_move_fuzzy_match_distance_3_rejected():
+    # Three edits — past the distance-2 threshold; must stay unchanged.
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", move1="Protxyz"))
+    normed, log = normalize(d, known_moves={"Protect"})
+    assert normed.pokemon[0].move1 == "Protxyz"
+    assert not any("move_fuzzy" in entry for entry in log)
+
+
+def test_pokemon_alias_no_op_when_already_canonical():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="Urshifu-Single-Strike"))
+    normed, log = normalize(d)
+    assert normed.pokemon[0].pokemon == "Urshifu-Single-Strike"
+    assert not any("pokemon_alias" in entry for entry in log)

--- a/tests/test_ingestion_normalizer.py
+++ b/tests/test_ingestion_normalizer.py
@@ -1,0 +1,50 @@
+from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
+from smogon_vgc_mcp.fetcher.ingestion.normalizer import normalize
+
+
+def _draft(*pokes: ChampionsTeamPokemon) -> ChampionsTeamDraft:
+    return ChampionsTeamDraft(
+        source_type="pokepaste",
+        source_url="https://x",
+        tier_baseline_confidence=1.0,
+        pokemon=list(pokes),
+    )
+
+
+def test_pokemon_alias_expanded():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="urshifu-s"))
+    normed, log = normalize(d)
+    assert normed.pokemon[0].pokemon == "Urshifu-Single-Strike"
+    assert any("pokemon_alias" in entry for entry in log)
+
+
+def test_move_fuzzy_match_distance_2():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", move1="Close Combatt"))
+    known_moves = {"Close Combat", "Moonblast", "Protect"}
+    normed, log = normalize(d, known_moves=known_moves)
+    assert normed.pokemon[0].move1 == "Close Combat"
+    assert any("move_fuzzy" in entry for entry in log)
+
+
+def test_move_fuzzy_no_match_left_alone():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", move1="Completely Unknown"))
+    normed, log = normalize(d, known_moves={"Close Combat"})
+    assert normed.pokemon[0].move1 == "Completely Unknown"
+
+
+def test_nature_title_case():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", nature="timid"))
+    normed, log = normalize(d)
+    assert normed.pokemon[0].nature == "Timid"
+
+
+def test_tera_title_case():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", tera_type="fairy"))
+    normed, log = normalize(d)
+    assert normed.pokemon[0].tera_type == "Fairy"
+
+
+def test_item_strip_consumed():
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", item="Focus Sash (consumed)"))
+    normed, log = normalize(d)
+    assert normed.pokemon[0].item == "Focus Sash"

--- a/tests/test_ingestion_normalizer.py
+++ b/tests/test_ingestion_normalizer.py
@@ -85,3 +85,13 @@ def test_pokemon_alias_no_op_when_already_canonical():
     normed, log = normalize(d)
     assert normed.pokemon[0].pokemon == "Urshifu-Single-Strike"
     assert not any("pokemon_alias" in entry for entry in log)
+
+
+def test_move_fuzzy_exact_match_left_unchanged():
+    # When a move already matches a known_moves entry exactly, it must
+    # be preserved and NOT produce a move_fuzzy log entry — otherwise
+    # every clean team would ship with spurious normalizations.
+    d = _draft(ChampionsTeamPokemon(slot=1, pokemon="X", move1="Close Combat"))
+    normed, log = normalize(d, known_moves={"Close Combat", "Protect"})
+    assert normed.pokemon[0].move1 == "Close Combat"
+    assert not any("move_fuzzy" in entry for entry in log)

--- a/tests/test_ingestion_pipeline.py
+++ b/tests/test_ingestion_pipeline.py
@@ -98,8 +98,9 @@ async def test_ingest_pokepaste_review_pending_when_confidence_low(db_path: Path
     assert "tera_type_unknown" in stored.review_reasons
 
 
-async def test_ingest_pokepaste_parse_exception_returns_parse_failed(db_path: Path):
-    # Force parse_pokepaste_to_champions_draft to raise; pipeline should wrap it.
+async def test_ingest_pokepaste_parse_exception_returns_fetch_failed(db_path: Path):
+    # Force parse_pokepaste_to_champions_draft to raise; pipeline wraps it
+    # into a FetchResult.fail(PARSE_ERROR) which surfaces as fetch_failed.
     def boom(*a, **kw):
         raise ValueError("boom")
 
@@ -117,6 +118,29 @@ async def test_ingest_pokepaste_parse_exception_returns_parse_failed(db_path: Pa
     assert result.status == "fetch_failed"
     assert result.reason is not None
     assert "Failed to parse pokepaste" in result.reason
+
+
+async def test_ingest_db_write_failure_returns_fetch_failed(db_path: Path):
+    text = FIXTURE.read_text()
+
+    async def boom(db, team):
+        raise RuntimeError("disk full")
+
+    with (
+        patch(
+            "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+            new=AsyncMock(return_value=FetchResult.ok(text)),
+        ),
+        patch(
+            "smogon_vgc_mcp.fetcher.ingestion.pipeline.write_or_queue_team",
+            new=boom,
+        ),
+    ):
+        result = await ingest_url("https://pokepast.es/dbfail", db_path=db_path)
+    assert result.status == "fetch_failed"
+    assert result.reason is not None
+    assert "db_write_error" in result.reason
+    assert result.team_row_id is None
 
 
 def test_score_arithmetic_matches_threshold():

--- a/tests/test_ingestion_pipeline.py
+++ b/tests/test_ingestion_pipeline.py
@@ -63,3 +63,78 @@ async def test_ingest_x_and_blog_not_implemented_yet(db_path: Path):
     result = await ingest_url("https://x.com/u/status/1", db_path=db_path)
     assert result.status == "rejected"
     assert result.reason == "tier_not_implemented"
+
+
+async def test_ingest_empty_pokepaste_returns_parse_failed(db_path: Path):
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.ok("")),
+    ):
+        result = await ingest_url("https://pokepast.es/empty", db_path=db_path)
+    assert result.status == "parse_failed"
+    assert result.team_row_id is None
+
+
+async def test_ingest_pokepaste_review_pending_when_confidence_low(db_path: Path):
+    # Two soft failures (unknown nature + unknown tera type) drops 1.0 → 0.8 < 0.85
+    text = (
+        "Koraidon @ Life Orb\nAbility: Orichalcum Pulse\nLevel: 50\n"
+        "Tera Type: Plasma\nEVs: 32 Atk\nFooNature Nature\n"
+        "- Flare Blitz\n- Protect\n- Collision Course\n- Dragon Claw"
+    )
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.ok(text)),
+    ):
+        result = await ingest_url("https://pokepast.es/soft", db_path=db_path)
+    assert result.status == "review_pending"
+    assert result.team_row_id is not None
+    assert result.confidence == pytest.approx(0.8)
+    async with get_connection(db_path) as db:
+        stored = await get_champions_team(db, result.team_row_id)
+    assert stored.ingestion_status == "review_pending"
+    assert stored.review_reasons is not None
+    assert "nature_unknown" in stored.review_reasons
+    assert "tera_type_unknown" in stored.review_reasons
+
+
+async def test_ingest_pokepaste_parse_exception_returns_parse_failed(db_path: Path):
+    # Force parse_pokepaste_to_champions_draft to raise; pipeline should wrap it.
+    def boom(*a, **kw):
+        raise ValueError("boom")
+
+    with (
+        patch(
+            "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+            new=AsyncMock(return_value=FetchResult.ok("anything")),
+        ),
+        patch(
+            "smogon_vgc_mcp.fetcher.ingestion.pipeline.parse_pokepaste_to_champions_draft",
+            new=boom,
+        ),
+    ):
+        result = await ingest_url("https://pokepast.es/exc", db_path=db_path)
+    assert result.status == "fetch_failed"
+    assert result.reason is not None
+    assert "Failed to parse pokepaste" in result.reason
+
+
+def test_score_arithmetic_matches_threshold():
+    from smogon_vgc_mcp.database.models import ChampionsTeamDraft
+    from smogon_vgc_mcp.fetcher.ingestion.pipeline import (
+        AUTO_WRITE_THRESHOLD,
+        _score,
+    )
+
+    draft = ChampionsTeamDraft(
+        source_type="pokepaste",
+        source_url="https://x",
+        tier_baseline_confidence=1.0,
+    )
+    assert _score(draft, 0) == pytest.approx(1.0)
+    assert _score(draft, 1) == pytest.approx(0.9)
+    assert _score(draft, 2) == pytest.approx(0.8)
+    assert _score(draft, 100) == 0.0
+    # one soft failure stays auto, two flips to review_pending
+    assert _score(draft, 1) >= AUTO_WRITE_THRESHOLD
+    assert _score(draft, 2) < AUTO_WRITE_THRESHOLD

--- a/tests/test_ingestion_pipeline.py
+++ b/tests/test_ingestion_pipeline.py
@@ -57,6 +57,9 @@ async def test_ingest_fetch_failure_returns_fetch_failed(db_path: Path):
         result = await ingest_url("https://pokepast.es/missing", db_path=db_path)
     assert result.status == "fetch_failed"
     assert result.team_row_id is None
+    # The CLI surfaces `reason` to users — must be the actionable
+    # message, not a dataclass repr.
+    assert result.reason == "404"
 
 
 async def test_ingest_x_and_blog_not_implemented_yet(db_path: Path):
@@ -141,6 +144,40 @@ async def test_ingest_db_write_failure_returns_fetch_failed(db_path: Path):
     assert result.reason is not None
     assert "db_write_error" in result.reason
     assert result.team_row_id is None
+    # Confidence is computed before the DB write, so it should still be
+    # populated to preserve the validator signal.
+    assert result.confidence is not None
+
+
+async def test_ingest_hard_failure_writes_review_pending_with_zero_confidence(db_path: Path):
+    # Duplicate species triggers a hard failure (`duplicate_species`)
+    # without violating DB CHECK constraints. Hard failures drop
+    # confidence to 0.0 and land below AUTO_WRITE_THRESHOLD, so the
+    # team is still persisted but marked review_pending. This behavior
+    # is intentional (preserve for audit) and covered here so future
+    # refactors can't silently flip it to 'rejected' without breaking
+    # a test.
+    text = (
+        "Koraidon @ Life Orb\nAbility: Orichalcum Pulse\nLevel: 50\n"
+        "Tera Type: Fire\nAdamant Nature\n"
+        "- Flare Blitz\n- Protect\n- Collision Course\n- Dragon Claw\n\n"
+        "Koraidon @ Choice Band\nAbility: Orichalcum Pulse\nLevel: 50\n"
+        "Tera Type: Fire\nAdamant Nature\n"
+        "- Flare Blitz\n- U-turn\n- Collision Course\n- Dragon Claw"
+    )
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.ok(text)),
+    ):
+        result = await ingest_url("https://pokepast.es/hardfail", db_path=db_path)
+    assert result.status == "review_pending"
+    assert result.confidence == pytest.approx(0.0)
+    assert result.team_row_id is not None
+    async with get_connection(db_path) as db:
+        stored = await get_champions_team(db, result.team_row_id)
+    assert stored.ingestion_status == "review_pending"
+    assert stored.review_reasons is not None
+    assert "duplicate_species" in stored.review_reasons
 
 
 def test_score_arithmetic_matches_threshold():

--- a/tests/test_ingestion_pipeline.py
+++ b/tests/test_ingestion_pipeline.py
@@ -101,9 +101,10 @@ async def test_ingest_pokepaste_review_pending_when_confidence_low(db_path: Path
     assert "tera_type_unknown" in stored.review_reasons
 
 
-async def test_ingest_pokepaste_parse_exception_returns_fetch_failed(db_path: Path):
-    # Force parse_pokepaste_to_champions_draft to raise; pipeline wraps it
-    # into a FetchResult.fail(PARSE_ERROR) which surfaces as fetch_failed.
+async def test_ingest_pokepaste_parse_exception_returns_parse_failed(db_path: Path):
+    # Force parse_pokepaste_to_champions_draft to raise; pipeline wraps
+    # it into a FetchResult.fail(PARSE_ERROR) which must surface as
+    # parse_failed (CLI exit 4), not fetch_failed (CLI exit 3).
     def boom(*a, **kw):
         raise ValueError("boom")
 
@@ -118,9 +119,22 @@ async def test_ingest_pokepaste_parse_exception_returns_fetch_failed(db_path: Pa
         ),
     ):
         result = await ingest_url("https://pokepast.es/exc", db_path=db_path)
-    assert result.status == "fetch_failed"
+    assert result.status == "parse_failed"
     assert result.reason is not None
     assert "Failed to parse pokepaste" in result.reason
+
+
+async def test_ingest_whitespace_body_returns_parse_failed(db_path: Path):
+    # Whitespace-only body parses to zero pokemon; the zero-pokemon
+    # branch in _fetch_tier1 returns FetchResult.ok(None), which the
+    # caller maps to parse_failed with reason="empty_parse".
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.ok("   \n\n   ")),
+    ):
+        result = await ingest_url("https://pokepast.es/ws", db_path=db_path)
+    assert result.status == "parse_failed"
+    assert result.reason == "empty_parse"
 
 
 async def test_ingest_db_write_failure_returns_db_error(db_path: Path):

--- a/tests/test_ingestion_pipeline.py
+++ b/tests/test_ingestion_pipeline.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from smogon_vgc_mcp.database.champions_team_queries import get_champions_team
+from smogon_vgc_mcp.database.schema import get_connection, init_database
+from smogon_vgc_mcp.fetcher.ingestion.pipeline import ingest_url
+from smogon_vgc_mcp.resilience import FetchResult
+
+FIXTURE = Path(__file__).parent / "fixtures" / "champions_pokepaste_sample.txt"
+
+
+@pytest.fixture
+async def db_path(tmp_path: Path):
+    p = tmp_path / "test.db"
+    await init_database(p)
+    return p
+
+
+async def test_ingest_unknown_url_returns_rejected(db_path: Path):
+    result = await ingest_url("not-a-url", db_path=db_path)
+    assert result.status == "rejected"
+    assert result.reason == "classifier_unknown_tier"
+    assert result.team_row_id is None
+
+
+async def test_ingest_pokepaste_auto_writes(db_path: Path):
+    text = FIXTURE.read_text()
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.ok(text)),
+    ):
+        result = await ingest_url("https://pokepast.es/abc", db_path=db_path)
+    assert result.status == "auto"
+    assert result.team_row_id is not None
+    async with get_connection(db_path) as db:
+        stored = await get_champions_team(db, result.team_row_id)
+    assert stored.ingestion_status == "auto"
+    assert stored.confidence_score == pytest.approx(1.0)
+    assert len(stored.pokemon) == 2
+
+
+async def test_ingest_fetch_failure_returns_fetch_failed(db_path: Path):
+    from smogon_vgc_mcp.resilience import ErrorCategory, ServiceError
+
+    err = ServiceError(
+        category=ErrorCategory.HTTP_CLIENT_ERROR,
+        service="pokepaste",
+        message="404",
+        is_recoverable=False,
+    )
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.fail(err)),
+    ):
+        result = await ingest_url("https://pokepast.es/missing", db_path=db_path)
+    assert result.status == "fetch_failed"
+    assert result.team_row_id is None
+
+
+async def test_ingest_x_and_blog_not_implemented_yet(db_path: Path):
+    result = await ingest_url("https://x.com/u/status/1", db_path=db_path)
+    assert result.status == "rejected"
+    assert result.reason == "tier_not_implemented"

--- a/tests/test_ingestion_pipeline.py
+++ b/tests/test_ingestion_pipeline.py
@@ -138,10 +138,12 @@ async def test_ingest_whitespace_body_returns_parse_failed(db_path: Path):
 
 
 async def test_ingest_db_write_failure_returns_db_error(db_path: Path):
+    import aiosqlite
+
     text = FIXTURE.read_text()
 
     async def boom(db, team):
-        raise RuntimeError("disk full")
+        raise aiosqlite.OperationalError("disk full")
 
     with (
         patch(
@@ -277,6 +279,23 @@ async def test_ingest_url_uses_provided_dex_to_flag_illegal_ability(db_path: Pat
         stored = await get_champions_team(db, result.team_row_id)
     assert stored.review_reasons is not None
     assert "ability_illegal" in stored.review_reasons
+
+
+async def test_ingest_same_url_twice_dedups_to_same_row(db_path: Path):
+    # Re-ingesting the same URL must yield the same team_row_id via
+    # the ``(format, team_id)`` dedup path in ``write_or_queue_team``
+    # — guards the champions-sheet re-run contract.
+    text = FIXTURE.read_text()
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.ok(text)),
+    ):
+        first = await ingest_url("https://pokepast.es/dedup", db_path=db_path)
+        second = await ingest_url("https://pokepast.es/dedup", db_path=db_path)
+    assert first.status == "auto"
+    assert second.status == "auto"
+    assert first.team_row_id is not None
+    assert first.team_row_id == second.team_row_id
 
 
 def test_score_arithmetic_matches_threshold():

--- a/tests/test_ingestion_pipeline.py
+++ b/tests/test_ingestion_pipeline.py
@@ -123,7 +123,7 @@ async def test_ingest_pokepaste_parse_exception_returns_fetch_failed(db_path: Pa
     assert "Failed to parse pokepaste" in result.reason
 
 
-async def test_ingest_db_write_failure_returns_fetch_failed(db_path: Path):
+async def test_ingest_db_write_failure_returns_db_error(db_path: Path):
     text = FIXTURE.read_text()
 
     async def boom(db, team):
@@ -140,7 +140,7 @@ async def test_ingest_db_write_failure_returns_fetch_failed(db_path: Path):
         ),
     ):
         result = await ingest_url("https://pokepast.es/dbfail", db_path=db_path)
-    assert result.status == "fetch_failed"
+    assert result.status == "db_error"
     assert result.reason is not None
     assert "db_write_error" in result.reason
     assert result.team_row_id is None
@@ -178,6 +178,66 @@ async def test_ingest_hard_failure_writes_review_pending_with_zero_confidence(db
     assert stored.ingestion_status == "review_pending"
     assert stored.review_reasons is not None
     assert "duplicate_species" in stored.review_reasons
+
+
+async def test_load_dex_lookup_returns_none_when_empty(db_path: Path):
+    from smogon_vgc_mcp.fetcher.ingestion.pipeline import load_dex_lookup
+
+    result = await load_dex_lookup(db_path)
+    assert result is None
+
+
+async def test_load_dex_lookup_builds_entries_from_populated_tables(db_path: Path):
+    from smogon_vgc_mcp.database.schema import get_connection
+    from smogon_vgc_mcp.fetcher.ingestion.pipeline import load_dex_lookup
+
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "INSERT INTO champions_dex_pokemon(id, name, type1, hp, atk, def, spa, spd, spe, "
+            "ability1, ability2, ability_hidden) VALUES "
+            "('koraidon', 'Koraidon', 'Dragon', 100, 100, 100, 100, 100, 100, "
+            "'Orichalcum Pulse', NULL, NULL)"
+        )
+        await db.execute(
+            "INSERT INTO champions_dex_moves(id, name, type, category) VALUES "
+            "('flareblitz', 'Flare Blitz', 'Fire', 'Physical')"
+        )
+        await db.execute(
+            "INSERT INTO champions_dex_learnsets(pokemon_id, move_id, method) VALUES "
+            "('koraidon', 'flareblitz', 'level-up')"
+        )
+        await db.commit()
+
+    result = await load_dex_lookup(db_path)
+    assert result is not None
+    entry = result["koraidon"]
+    assert entry["abilities"] == ["Orichalcum Pulse"]
+    assert entry["moves"] == ["Flare Blitz"]
+
+
+async def test_ingest_url_uses_provided_dex_to_flag_illegal_ability(db_path: Path):
+    # Koraidon's only legal ability here is Orichalcum Pulse; the
+    # pokepaste claims "Fake Ability" so the soft failure ability_illegal
+    # must fire. Two soft failures drop confidence to 0.8 < threshold.
+    dex_lookup = {
+        "koraidon": {"abilities": ["Orichalcum Pulse"], "moves": ["Flare Blitz"]},
+    }
+    text = (
+        "Koraidon @ Life Orb\nAbility: Fake Ability\nLevel: 50\nEVs: 32 Atk\n"
+        "Adamant Nature\n- Flare Blitz\n- Flare Blitz\n- Flare Blitz\n- Flare Blitz"
+    )
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+        new=AsyncMock(return_value=FetchResult.ok(text)),
+    ):
+        result = await ingest_url(
+            "https://pokepast.es/abil", db_path=db_path, dex_lookup=dex_lookup
+        )
+    assert result.team_row_id is not None
+    async with get_connection(db_path) as db:
+        stored = await get_champions_team(db, result.team_row_id)
+    assert stored.review_reasons is not None
+    assert "ability_illegal" in stored.review_reasons
 
 
 def test_score_arithmetic_matches_threshold():

--- a/tests/test_ingestion_pipeline.py
+++ b/tests/test_ingestion_pipeline.py
@@ -201,6 +201,31 @@ async def test_load_dex_lookup_returns_none_when_empty(db_path: Path):
     assert result is None
 
 
+async def test_load_dex_lookup_returns_none_on_db_error(db_path: Path):
+    # A corrupt/missing dex table must not take down the pipeline — the
+    # narrow `(aiosqlite.Error, OSError)` guard in load_dex_lookup turns
+    # DB failure into a skip-signal (None) so SP/shape/vocab validation
+    # can still proceed. Guards against a regression that widens or
+    # removes the except clause.
+    import aiosqlite
+
+    from smogon_vgc_mcp.fetcher.ingestion.pipeline import load_dex_lookup
+
+    class FailingConn:
+        async def __aenter__(self):
+            raise aiosqlite.OperationalError("simulated corrupt dex")
+
+        async def __aexit__(self, *_):
+            return False
+
+    with patch(
+        "smogon_vgc_mcp.fetcher.ingestion.pipeline.get_connection",
+        return_value=FailingConn(),
+    ):
+        result = await load_dex_lookup(db_path)
+    assert result is None
+
+
 async def test_load_dex_lookup_builds_entries_from_populated_tables(db_path: Path):
     from smogon_vgc_mcp.database.schema import get_connection
     from smogon_vgc_mcp.fetcher.ingestion.pipeline import load_dex_lookup

--- a/tests/test_ingestion_tier1.py
+++ b/tests/test_ingestion_tier1.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+from smogon_vgc_mcp.fetcher.ingestion.tier1_pokepaste import (
+    parse_pokepaste_to_champions_draft,
+)
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "champions_pokepaste_sample.txt"
+
+
+def test_tier1_parses_two_pokemon():
+    text = FIXTURE.read_text()
+    draft = parse_pokepaste_to_champions_draft(
+        text, source_url="https://pokepast.es/fixt"
+    )
+    assert len(draft.pokemon) == 2
+    assert draft.pokemon[0].pokemon == "Koraidon"
+    assert draft.pokemon[1].pokemon == "Flutter Mane"
+
+
+def test_tier1_maps_evs_to_sp():
+    text = FIXTURE.read_text()
+    draft = parse_pokepaste_to_champions_draft(
+        text, source_url="https://pokepast.es/fixt"
+    )
+    kor = draft.pokemon[0]
+    assert kor.sp_atk == 32
+    assert kor.sp_spe == 32
+    assert kor.sp_hp == 0
+
+
+def test_tier1_captures_item_ability_nature_tera():
+    text = FIXTURE.read_text()
+    draft = parse_pokepaste_to_champions_draft(
+        text, source_url="https://pokepast.es/fixt"
+    )
+    kor = draft.pokemon[0]
+    assert kor.item == "Life Orb"
+    assert kor.ability == "Orichalcum Pulse"
+    assert kor.nature == "Adamant"
+    assert kor.tera_type == "Fire"
+
+
+def test_tier1_captures_moves():
+    text = FIXTURE.read_text()
+    draft = parse_pokepaste_to_champions_draft(
+        text, source_url="https://pokepast.es/fixt"
+    )
+    kor = draft.pokemon[0]
+    assert kor.move1 == "Flare Blitz"
+    assert kor.move4 == "Dragon Claw"
+
+
+def test_tier1_sets_source_type_and_baseline_confidence():
+    text = FIXTURE.read_text()
+    draft = parse_pokepaste_to_champions_draft(
+        text, source_url="https://pokepast.es/fixt"
+    )
+    assert draft.source_type == "pokepaste"
+    assert draft.tier_baseline_confidence == 1.0

--- a/tests/test_ingestion_tier1.py
+++ b/tests/test_ingestion_tier1.py
@@ -1,19 +1,15 @@
 from pathlib import Path
 
-import pytest
 from smogon_vgc_mcp.fetcher.ingestion.tier1_pokepaste import (
     parse_pokepaste_to_champions_draft,
 )
-
 
 FIXTURE = Path(__file__).parent / "fixtures" / "champions_pokepaste_sample.txt"
 
 
 def test_tier1_parses_two_pokemon():
     text = FIXTURE.read_text()
-    draft = parse_pokepaste_to_champions_draft(
-        text, source_url="https://pokepast.es/fixt"
-    )
+    draft = parse_pokepaste_to_champions_draft(text, source_url="https://pokepast.es/fixt")
     assert len(draft.pokemon) == 2
     assert draft.pokemon[0].pokemon == "Koraidon"
     assert draft.pokemon[1].pokemon == "Flutter Mane"
@@ -21,9 +17,7 @@ def test_tier1_parses_two_pokemon():
 
 def test_tier1_maps_evs_to_sp():
     text = FIXTURE.read_text()
-    draft = parse_pokepaste_to_champions_draft(
-        text, source_url="https://pokepast.es/fixt"
-    )
+    draft = parse_pokepaste_to_champions_draft(text, source_url="https://pokepast.es/fixt")
     kor = draft.pokemon[0]
     assert kor.sp_atk == 32
     assert kor.sp_spe == 32
@@ -32,9 +26,7 @@ def test_tier1_maps_evs_to_sp():
 
 def test_tier1_captures_item_ability_nature_tera():
     text = FIXTURE.read_text()
-    draft = parse_pokepaste_to_champions_draft(
-        text, source_url="https://pokepast.es/fixt"
-    )
+    draft = parse_pokepaste_to_champions_draft(text, source_url="https://pokepast.es/fixt")
     kor = draft.pokemon[0]
     assert kor.item == "Life Orb"
     assert kor.ability == "Orichalcum Pulse"
@@ -44,9 +36,7 @@ def test_tier1_captures_item_ability_nature_tera():
 
 def test_tier1_captures_moves():
     text = FIXTURE.read_text()
-    draft = parse_pokepaste_to_champions_draft(
-        text, source_url="https://pokepast.es/fixt"
-    )
+    draft = parse_pokepaste_to_champions_draft(text, source_url="https://pokepast.es/fixt")
     kor = draft.pokemon[0]
     assert kor.move1 == "Flare Blitz"
     assert kor.move4 == "Dragon Claw"
@@ -54,8 +44,6 @@ def test_tier1_captures_moves():
 
 def test_tier1_sets_source_type_and_baseline_confidence():
     text = FIXTURE.read_text()
-    draft = parse_pokepaste_to_champions_draft(
-        text, source_url="https://pokepast.es/fixt"
-    )
+    draft = parse_pokepaste_to_champions_draft(text, source_url="https://pokepast.es/fixt")
     assert draft.source_type == "pokepaste"
     assert draft.tier_baseline_confidence == 1.0

--- a/tests/test_ingestion_validator.py
+++ b/tests/test_ingestion_validator.py
@@ -24,9 +24,17 @@ def test_sp_over_per_stat_flagged():
 
 
 def test_sp_over_total_flagged():
-    rep = validate(_draft(ChampionsTeamPokemon(
-        slot=1, pokemon="X", sp_hp=32, sp_atk=32, sp_def=10,
-    )))
+    rep = validate(
+        _draft(
+            ChampionsTeamPokemon(
+                slot=1,
+                pokemon="X",
+                sp_hp=32,
+                sp_atk=32,
+                sp_def=10,
+            )
+        )
+    )
     assert not rep.passed
     assert "sp_over_total" in rep.hard_failures
 
@@ -44,10 +52,20 @@ def test_boundary_32_ok():
 
 def test_boundary_66_total_ok():
     # 11 each across 6 stats = 66
-    rep = validate(_draft(ChampionsTeamPokemon(
-        slot=1, pokemon="X",
-        sp_hp=11, sp_atk=11, sp_def=11, sp_spa=11, sp_spd=11, sp_spe=11,
-    )))
+    rep = validate(
+        _draft(
+            ChampionsTeamPokemon(
+                slot=1,
+                pokemon="X",
+                sp_hp=11,
+                sp_atk=11,
+                sp_def=11,
+                sp_spa=11,
+                sp_spd=11,
+                sp_spe=11,
+            )
+        )
+    )
     assert "sp_over_total" not in rep.hard_failures
 
 
@@ -69,18 +87,22 @@ def test_six_slots_ok():
 
 
 def test_duplicate_species_flagged():
-    rep = validate(_draft(
-        ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"),
-        ChampionsTeamPokemon(slot=2, pokemon="Flutter Mane"),
-    ))
+    rep = validate(
+        _draft(
+            ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"),
+            ChampionsTeamPokemon(slot=2, pokemon="Flutter Mane"),
+        )
+    )
     assert "duplicate_species" in rep.hard_failures
 
 
 def test_species_clause_case_insensitive():
-    rep = validate(_draft(
-        ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"),
-        ChampionsTeamPokemon(slot=2, pokemon="flutter mane"),
-    ))
+    rep = validate(
+        _draft(
+            ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"),
+            ChampionsTeamPokemon(slot=2, pokemon="flutter mane"),
+        )
+    )
     assert "duplicate_species" in rep.hard_failures
 
 
@@ -106,9 +128,13 @@ def test_pokemon_unknown_flagged():
 
 def test_ability_illegal_flagged_as_soft():
     rep = validate(
-        _draft(ChampionsTeamPokemon(
-            slot=1, pokemon="Flutter Mane", ability="Levitate",
-        )),
+        _draft(
+            ChampionsTeamPokemon(
+                slot=1,
+                pokemon="Flutter Mane",
+                ability="Levitate",
+            )
+        ),
         dex_lookup=FAKE_DEX,
     )
     assert "ability_illegal" in rep.soft_failures
@@ -117,10 +143,13 @@ def test_ability_illegal_flagged_as_soft():
 
 def test_move_illegal_flagged_as_soft():
     rep = validate(
-        _draft(ChampionsTeamPokemon(
-            slot=1, pokemon="Flutter Mane",
-            move1="Flare Blitz",  # not in Flutter Mane learnset
-        )),
+        _draft(
+            ChampionsTeamPokemon(
+                slot=1,
+                pokemon="Flutter Mane",
+                move1="Flare Blitz",  # not in Flutter Mane learnset
+            )
+        ),
         dex_lookup=FAKE_DEX,
     )
     assert "move_illegal" in rep.soft_failures
@@ -128,11 +157,17 @@ def test_move_illegal_flagged_as_soft():
 
 def test_legal_ability_and_moves_ok():
     rep = validate(
-        _draft(ChampionsTeamPokemon(
-            slot=1, pokemon="Flutter Mane",
-            ability="Protosynthesis",
-            move1="Moonblast", move2="Shadow Ball", move3="Protect", move4="Icy Wind",
-        )),
+        _draft(
+            ChampionsTeamPokemon(
+                slot=1,
+                pokemon="Flutter Mane",
+                ability="Protosynthesis",
+                move1="Moonblast",
+                move2="Shadow Ball",
+                move3="Protect",
+                move4="Icy Wind",
+            )
+        ),
         dex_lookup=FAKE_DEX,
     )
     assert "ability_illegal" not in rep.soft_failures
@@ -140,30 +175,38 @@ def test_legal_ability_and_moves_ok():
 
 
 def test_nature_unknown_soft():
-    rep = validate(_draft(
-        ChampionsTeamPokemon(slot=1, pokemon="X", nature="Weird"),
-    ))
+    rep = validate(
+        _draft(
+            ChampionsTeamPokemon(slot=1, pokemon="X", nature="Weird"),
+        )
+    )
     assert "nature_unknown" in rep.soft_failures
 
 
 def test_nature_known_ok():
-    rep = validate(_draft(
-        ChampionsTeamPokemon(slot=1, pokemon="X", nature="Timid"),
-    ))
+    rep = validate(
+        _draft(
+            ChampionsTeamPokemon(slot=1, pokemon="X", nature="Timid"),
+        )
+    )
     assert "nature_unknown" not in rep.soft_failures
 
 
 def test_tera_type_unknown_soft():
-    rep = validate(_draft(
-        ChampionsTeamPokemon(slot=1, pokemon="X", tera_type="Banana"),
-    ))
+    rep = validate(
+        _draft(
+            ChampionsTeamPokemon(slot=1, pokemon="X", tera_type="Banana"),
+        )
+    )
     assert "tera_type_unknown" in rep.soft_failures
 
 
 def test_tera_type_none_ok():
-    rep = validate(_draft(
-        ChampionsTeamPokemon(slot=1, pokemon="X", tera_type=None),
-    ))
+    rep = validate(
+        _draft(
+            ChampionsTeamPokemon(slot=1, pokemon="X", tera_type=None),
+        )
+    )
     assert "tera_type_unknown" not in rep.soft_failures
 
 
@@ -174,8 +217,16 @@ def test_move_count_zero_soft():
 
 
 def test_move_count_four_ok():
-    rep = validate(_draft(ChampionsTeamPokemon(
-        slot=1, pokemon="X",
-        move1="a", move2="b", move3="c", move4="d",
-    )))
+    rep = validate(
+        _draft(
+            ChampionsTeamPokemon(
+                slot=1,
+                pokemon="X",
+                move1="a",
+                move2="b",
+                move3="c",
+                move4="d",
+            )
+        )
+    )
     assert "move_count" not in rep.soft_failures

--- a/tests/test_ingestion_validator.py
+++ b/tests/test_ingestion_validator.py
@@ -137,3 +137,45 @@ def test_legal_ability_and_moves_ok():
     )
     assert "ability_illegal" not in rep.soft_failures
     assert "move_illegal" not in rep.soft_failures
+
+
+def test_nature_unknown_soft():
+    rep = validate(_draft(
+        ChampionsTeamPokemon(slot=1, pokemon="X", nature="Weird"),
+    ))
+    assert "nature_unknown" in rep.soft_failures
+
+
+def test_nature_known_ok():
+    rep = validate(_draft(
+        ChampionsTeamPokemon(slot=1, pokemon="X", nature="Timid"),
+    ))
+    assert "nature_unknown" not in rep.soft_failures
+
+
+def test_tera_type_unknown_soft():
+    rep = validate(_draft(
+        ChampionsTeamPokemon(slot=1, pokemon="X", tera_type="Banana"),
+    ))
+    assert "tera_type_unknown" in rep.soft_failures
+
+
+def test_tera_type_none_ok():
+    rep = validate(_draft(
+        ChampionsTeamPokemon(slot=1, pokemon="X", tera_type=None),
+    ))
+    assert "tera_type_unknown" not in rep.soft_failures
+
+
+def test_move_count_zero_soft():
+    # no moves at all
+    rep = validate(_draft(ChampionsTeamPokemon(slot=1, pokemon="X")))
+    assert "move_count" in rep.soft_failures
+
+
+def test_move_count_four_ok():
+    rep = validate(_draft(ChampionsTeamPokemon(
+        slot=1, pokemon="X",
+        move1="a", move2="b", move3="c", move4="d",
+    )))
+    assert "move_count" not in rep.soft_failures

--- a/tests/test_ingestion_validator.py
+++ b/tests/test_ingestion_validator.py
@@ -237,6 +237,30 @@ def test_move_count_zero_soft():
     assert "move_count" in rep.soft_failures
 
 
+def test_soft_failure_codes_deduped_across_pokemon():
+    # Two pokemon both with illegal abilities must still produce
+    # exactly one ``ability_illegal`` entry — the outer validator loop
+    # dedupes soft codes across the whole team so the review UI shows
+    # each reason once regardless of how many pokemon trigger it.
+    rep = validate(
+        _draft(
+            ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane", ability="Levitate"),
+            ChampionsTeamPokemon(slot=2, pokemon="Koraidon", ability="Drought"),
+        ),
+        dex_lookup=FAKE_DEX,
+    )
+    assert rep.soft_failures.count("ability_illegal") == 1
+
+
+def test_stellar_tera_is_accepted():
+    # Stellar was added in Gen 9 DLC2 and is a legal tera for
+    # restricted Paradox legends; it must not be flagged as unknown.
+    rep = validate(
+        _draft(ChampionsTeamPokemon(slot=1, pokemon="Koraidon", tera_type="Stellar")),
+    )
+    assert "tera_type_unknown" not in rep.soft_failures
+
+
 def test_move_count_four_ok():
     rep = validate(
         _draft(

--- a/tests/test_ingestion_validator.py
+++ b/tests/test_ingestion_validator.py
@@ -49,3 +49,36 @@ def test_boundary_66_total_ok():
         sp_hp=11, sp_atk=11, sp_def=11, sp_spa=11, sp_spd=11, sp_spe=11,
     )))
     assert "sp_over_total" not in rep.hard_failures
+
+
+def test_empty_team_flagged():
+    rep = validate(_draft())
+    assert "slot_count" in rep.hard_failures
+
+
+def test_seven_slots_flagged():
+    pokes = [ChampionsTeamPokemon(slot=i, pokemon=f"P{i}") for i in range(1, 8)]
+    rep = validate(_draft(*pokes))
+    assert "slot_count" in rep.hard_failures
+
+
+def test_six_slots_ok():
+    pokes = [ChampionsTeamPokemon(slot=i, pokemon=f"P{i}") for i in range(1, 7)]
+    rep = validate(_draft(*pokes))
+    assert "slot_count" not in rep.hard_failures
+
+
+def test_duplicate_species_flagged():
+    rep = validate(_draft(
+        ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"),
+        ChampionsTeamPokemon(slot=2, pokemon="Flutter Mane"),
+    ))
+    assert "duplicate_species" in rep.hard_failures
+
+
+def test_species_clause_case_insensitive():
+    rep = validate(_draft(
+        ChampionsTeamPokemon(slot=1, pokemon="Flutter Mane"),
+        ChampionsTeamPokemon(slot=2, pokemon="flutter mane"),
+    ))
+    assert "duplicate_species" in rep.hard_failures

--- a/tests/test_ingestion_validator.py
+++ b/tests/test_ingestion_validator.py
@@ -1,0 +1,51 @@
+from smogon_vgc_mcp.database.models import ChampionsTeamDraft, ChampionsTeamPokemon
+from smogon_vgc_mcp.fetcher.ingestion.validator import validate
+
+
+def _draft(*pokes: ChampionsTeamPokemon) -> ChampionsTeamDraft:
+    return ChampionsTeamDraft(
+        source_type="pokepaste",
+        source_url="https://pokepast.es/x",
+        tier_baseline_confidence=1.0,
+        pokemon=list(pokes),
+    )
+
+
+def test_valid_team_passes():
+    rep = validate(_draft(ChampionsTeamPokemon(slot=1, pokemon="Koraidon", sp_atk=32, sp_spe=32)))
+    assert rep.passed
+    assert rep.hard_failures == []
+
+
+def test_sp_over_per_stat_flagged():
+    rep = validate(_draft(ChampionsTeamPokemon(slot=1, pokemon="X", sp_atk=33)))
+    assert not rep.passed
+    assert "sp_over_per_stat" in rep.hard_failures
+
+
+def test_sp_over_total_flagged():
+    rep = validate(_draft(ChampionsTeamPokemon(
+        slot=1, pokemon="X", sp_hp=32, sp_atk=32, sp_def=10,
+    )))
+    assert not rep.passed
+    assert "sp_over_total" in rep.hard_failures
+
+
+def test_sp_negative_flagged():
+    rep = validate(_draft(ChampionsTeamPokemon(slot=1, pokemon="X", sp_atk=-1)))
+    assert not rep.passed
+    assert "sp_negative" in rep.hard_failures
+
+
+def test_boundary_32_ok():
+    rep = validate(_draft(ChampionsTeamPokemon(slot=1, pokemon="X", sp_atk=32)))
+    assert "sp_over_per_stat" not in rep.hard_failures
+
+
+def test_boundary_66_total_ok():
+    # 11 each across 6 stats = 66
+    rep = validate(_draft(ChampionsTeamPokemon(
+        slot=1, pokemon="X",
+        sp_hp=11, sp_atk=11, sp_def=11, sp_spa=11, sp_spd=11, sp_spe=11,
+    )))
+    assert "sp_over_total" not in rep.hard_failures

--- a/tests/test_ingestion_validator.py
+++ b/tests/test_ingestion_validator.py
@@ -82,3 +82,58 @@ def test_species_clause_case_insensitive():
         ChampionsTeamPokemon(slot=2, pokemon="flutter mane"),
     ))
     assert "duplicate_species" in rep.hard_failures
+
+
+FAKE_DEX = {
+    "flutter mane": {
+        "abilities": ["Protosynthesis"],
+        "moves": ["Moonblast", "Shadow Ball", "Protect", "Dazzling Gleam", "Icy Wind"],
+    },
+    "koraidon": {
+        "abilities": ["Orichalcum Pulse"],
+        "moves": ["Flare Blitz", "Collision Course", "Protect", "Dragon Claw"],
+    },
+}
+
+
+def test_pokemon_unknown_flagged():
+    rep = validate(
+        _draft(ChampionsTeamPokemon(slot=1, pokemon="Fake Pokemon")),
+        dex_lookup=FAKE_DEX,
+    )
+    assert "pokemon_unknown" in rep.hard_failures
+
+
+def test_ability_illegal_flagged_as_soft():
+    rep = validate(
+        _draft(ChampionsTeamPokemon(
+            slot=1, pokemon="Flutter Mane", ability="Levitate",
+        )),
+        dex_lookup=FAKE_DEX,
+    )
+    assert "ability_illegal" in rep.soft_failures
+    assert rep.passed  # soft failures don't fail the report
+
+
+def test_move_illegal_flagged_as_soft():
+    rep = validate(
+        _draft(ChampionsTeamPokemon(
+            slot=1, pokemon="Flutter Mane",
+            move1="Flare Blitz",  # not in Flutter Mane learnset
+        )),
+        dex_lookup=FAKE_DEX,
+    )
+    assert "move_illegal" in rep.soft_failures
+
+
+def test_legal_ability_and_moves_ok():
+    rep = validate(
+        _draft(ChampionsTeamPokemon(
+            slot=1, pokemon="Flutter Mane",
+            ability="Protosynthesis",
+            move1="Moonblast", move2="Shadow Ball", move3="Protect", move4="Icy Wind",
+        )),
+        dex_lookup=FAKE_DEX,
+    )
+    assert "ability_illegal" not in rep.soft_failures
+    assert "move_illegal" not in rep.soft_failures

--- a/tests/test_ingestion_validator.py
+++ b/tests/test_ingestion_validator.py
@@ -14,7 +14,7 @@ def _draft(*pokes: ChampionsTeamPokemon) -> ChampionsTeamDraft:
 def test_valid_team_passes():
     rep = validate(_draft(ChampionsTeamPokemon(slot=1, pokemon="Koraidon", sp_atk=32, sp_spe=32)))
     assert rep.passed
-    assert rep.hard_failures == []
+    assert rep.hard_failures == ()
 
 
 def test_sp_over_per_stat_flagged():

--- a/tests/test_ingestion_validator.py
+++ b/tests/test_ingestion_validator.py
@@ -155,6 +155,27 @@ def test_move_illegal_flagged_as_soft():
     assert "move_illegal" in rep.soft_failures
 
 
+def test_multiple_illegal_moves_all_flagged_per_pokemon():
+    # Pre-cycle-2: validator broke after the first illegal move so the second
+    # was never inspected. After fix, the inner loop visits every move; the
+    # outer dedup still collapses repeats from a single Pokemon to one entry,
+    # but removing the break is required so a Pokemon with move1 legal +
+    # move2 illegal is still flagged.
+    rep = validate(
+        _draft(
+            ChampionsTeamPokemon(
+                slot=1,
+                pokemon="Flutter Mane",
+                move1="Moonblast",  # legal
+                move2="Flare Blitz",  # illegal
+                move3="Earthquake",  # also illegal, should still be visited
+            )
+        ),
+        dex_lookup=FAKE_DEX,
+    )
+    assert "move_illegal" in rep.soft_failures
+
+
 def test_legal_ability_and_moves_ok():
     rep = validate(
         _draft(

--- a/tests/test_sheets_champions.py
+++ b/tests/test_sheets_champions.py
@@ -44,3 +44,53 @@ async def test_ingest_champions_sheet_routes_by_url_shape(db_path: Path):
     assert report["auto"] == 1
     assert report["rejected"] == 2
     assert report["fetch_failed"] == 0
+
+
+async def test_ingest_champions_sheet_fetch_failure_records_counter(db_path: Path):
+    from smogon_vgc_mcp.resilience import ErrorCategory, ServiceError
+
+    err = ServiceError(
+        category=ErrorCategory.HTTP_CLIENT_ERROR,
+        service="sheets",
+        message="503",
+        is_recoverable=True,
+    )
+    with patch(
+        "smogon_vgc_mcp.fetcher.sheets.fetch_text_resilient",
+        new=AsyncMock(return_value=FetchResult.fail(err)),
+    ):
+        report = await ingest_champions_sheet(db_path=db_path)
+    assert report["fetch_failed"] == 1
+    assert report["auto"] == 0
+    assert report["rejected"] == 0
+
+
+async def test_ingest_champions_sheet_per_row_exception_isolated(db_path: Path):
+    sheet_csv = "URL\nhttps://pokepast.es/a\nhttps://pokepast.es/b\n"
+    call_count = {"n": 0}
+
+    async def flaky_fetch(url: str):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("simulated transient error")
+        return FetchResult.ok(
+            "Koraidon @ Life Orb\nAbility: Orichalcum Pulse\nLevel: 50\n"
+            "EVs: 32 Atk\nAdamant Nature\n"
+            "- Flare Blitz\n- Protect\n- Collision Course\n- Dragon Claw"
+        )
+
+    with (
+        patch(
+            "smogon_vgc_mcp.fetcher.sheets.fetch_text_resilient",
+            new=AsyncMock(return_value=FetchResult.ok(sheet_csv)),
+        ),
+        patch(
+            "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+            new=flaky_fetch,
+        ),
+    ):
+        report = await ingest_champions_sheet(db_path=db_path)
+
+    # First row crashes → fetch_failed, second succeeds → auto
+    assert report["fetch_failed"] == 1
+    assert report["auto"] == 1

--- a/tests/test_sheets_champions.py
+++ b/tests/test_sheets_champions.py
@@ -90,23 +90,49 @@ async def test_ingest_champions_sheet_initializes_fresh_db(tmp_path: Path):
     assert report["auto"] == 1
 
 
-async def test_ingest_champions_sheet_returns_empty_when_no_sheet_gid(db_path: Path):
-    # Guard against config drift: if champions_ma ever loses its
-    # sheet_gid, ingest_champions_sheet must return a fully-formed
-    # counter dict (not raise, not return a partial dict) so callers
-    # can still parse the result.
+async def test_ingest_champions_sheet_no_sheet_gid_signals_fetch_failed(db_path: Path):
+    # Config drift (missing sheet_gid) must surface in the counter dict
+    # so scripts that compare counts against zero can distinguish it
+    # from a successful run over an empty sheet.
     with patch(
         "smogon_vgc_mcp.fetcher.sheets.get_sheet_csv_url",
         return_value=None,
     ):
         report = await ingest_champions_sheet(db_path=db_path)
+    assert report["fetch_failed"] == 1
     assert report["auto"] == 0
     assert report["review_pending"] == 0
     assert report["rejected"] == 0
-    assert report["fetch_failed"] == 0
     assert report["parse_failed"] == 0
     assert report["db_error"] == 0
     assert report["unexpected_error"] == 0
+
+
+async def test_ingest_champions_sheet_empty_body_signals_fetch_failed(db_path: Path):
+    # A success-but-empty-body response (e.g. a 200 that returned
+    # scrubbed HTML or a CDN stub) must still land in fetch_failed —
+    # the guard on ``not fetched.data`` covers both None and "".
+    with patch(
+        "smogon_vgc_mcp.fetcher.sheets.fetch_text_resilient",
+        new=AsyncMock(return_value=FetchResult.ok(None)),
+    ):
+        report = await ingest_champions_sheet(db_path=db_path)
+    assert report["fetch_failed"] == 1
+    assert report["auto"] == 0
+
+
+async def test_ingest_champions_sheet_rows_without_urls_are_skipped(db_path: Path):
+    # Rows with no http(s) URL column must be silently skipped — no
+    # crash, no counter increment. Guards against a regression where
+    # the ``if not url: continue`` check is removed.
+    header_only_csv = "Owner,Tournament,Rank,URL\nAlice,Regional,Top 8,\nBob,Regional,Winner,\n"
+    with patch(
+        "smogon_vgc_mcp.fetcher.sheets.fetch_text_resilient",
+        new=AsyncMock(return_value=FetchResult.ok(header_only_csv)),
+    ):
+        report = await ingest_champions_sheet(db_path=db_path)
+    # No URLs → all counters stay at zero.
+    assert all(v == 0 for v in report.values())
 
 
 async def test_ingest_champions_sheet_per_row_exception_isolated(db_path: Path):

--- a/tests/test_sheets_champions.py
+++ b/tests/test_sheets_champions.py
@@ -106,6 +106,7 @@ async def test_ingest_champions_sheet_returns_empty_when_no_sheet_gid(db_path: P
     assert report["fetch_failed"] == 0
     assert report["parse_failed"] == 0
     assert report["db_error"] == 0
+    assert report["unexpected_error"] == 0
 
 
 async def test_ingest_champions_sheet_per_row_exception_isolated(db_path: Path):
@@ -134,6 +135,9 @@ async def test_ingest_champions_sheet_per_row_exception_isolated(db_path: Path):
     ):
         report = await ingest_champions_sheet(db_path=db_path)
 
-    # First row crashes → fetch_failed, second succeeds → auto
-    assert report["fetch_failed"] == 1
+    # First row crashes inside the pipeline (not a FetchResult.fail) →
+    # unexpected_error bucket; the sheet-level fetch_failed bucket is
+    # reserved for the sheet-fetch itself failing.
+    assert report["unexpected_error"] == 1
+    assert report["fetch_failed"] == 0
     assert report["auto"] == 1

--- a/tests/test_sheets_champions.py
+++ b/tests/test_sheets_champions.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from smogon_vgc_mcp.database.schema import init_database
+from smogon_vgc_mcp.fetcher.sheets import ingest_champions_sheet
+from smogon_vgc_mcp.resilience import FetchResult
+
+
+@pytest.fixture
+async def db_path(tmp_path: Path):
+    p = tmp_path / "test.db"
+    await init_database(p)
+    return p
+
+
+MIXED_SHEET_CSV = """Owner,Tournament,Rank,URL
+Alice,Regional A,Top 8,https://pokepast.es/abc123
+Bob,Regional B,Winner,https://x.com/bob/status/42
+Carol,Regional C,Top 4,https://someblog.example/post
+"""
+
+
+async def test_ingest_champions_sheet_routes_by_url_shape(db_path: Path):
+    pokepaste_text = (
+        "Koraidon @ Life Orb\nAbility: Orichalcum Pulse\nLevel: 50\nEVs: 32 Atk\n"
+        "Adamant Nature\n- Flare Blitz\n- Protect\n- Collision Course\n- Dragon Claw"
+    )
+
+    with (
+        patch(
+            "smogon_vgc_mcp.fetcher.sheets.fetch_text_resilient",
+            new=AsyncMock(return_value=FetchResult.ok(MIXED_SHEET_CSV)),
+        ),
+        patch(
+            "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+            new=AsyncMock(return_value=FetchResult.ok(pokepaste_text)),
+        ),
+    ):
+        report = await ingest_champions_sheet(db_path=db_path)
+
+    # 3 rows: 1 pokepaste (auto), 2 rejected as tier_not_implemented
+    assert report["auto"] == 1
+    assert report["rejected"] == 2
+    assert report["fetch_failed"] == 0

--- a/tests/test_sheets_champions.py
+++ b/tests/test_sheets_champions.py
@@ -65,6 +65,31 @@ async def test_ingest_champions_sheet_fetch_failure_records_counter(db_path: Pat
     assert report["rejected"] == 0
 
 
+async def test_ingest_champions_sheet_initializes_fresh_db(tmp_path: Path):
+    # No pre-init — exercises the cycle-1 init_database call inside
+    # ingest_champions_sheet so a brand-new install survives the first run.
+    fresh_db = tmp_path / "fresh.db"
+    sheet_csv = "URL\nhttps://pokepast.es/abc\n"
+    pokepaste_text = (
+        "Koraidon @ Life Orb\nAbility: Orichalcum Pulse\nLevel: 50\n"
+        "EVs: 32 Atk\nAdamant Nature\n"
+        "- Flare Blitz\n- Protect\n- Collision Course\n- Dragon Claw"
+    )
+    with (
+        patch(
+            "smogon_vgc_mcp.fetcher.sheets.fetch_text_resilient",
+            new=AsyncMock(return_value=FetchResult.ok(sheet_csv)),
+        ),
+        patch(
+            "smogon_vgc_mcp.fetcher.ingestion.pipeline.fetch_pokepaste",
+            new=AsyncMock(return_value=FetchResult.ok(pokepaste_text)),
+        ),
+    ):
+        report = await ingest_champions_sheet(db_path=fresh_db)
+    assert fresh_db.exists()
+    assert report["auto"] == 1
+
+
 async def test_ingest_champions_sheet_per_row_exception_isolated(db_path: Path):
     sheet_csv = "URL\nhttps://pokepast.es/a\nhttps://pokepast.es/b\n"
     call_count = {"n": 0}

--- a/tests/test_sheets_champions.py
+++ b/tests/test_sheets_champions.py
@@ -90,6 +90,24 @@ async def test_ingest_champions_sheet_initializes_fresh_db(tmp_path: Path):
     assert report["auto"] == 1
 
 
+async def test_ingest_champions_sheet_returns_empty_when_no_sheet_gid(db_path: Path):
+    # Guard against config drift: if champions_ma ever loses its
+    # sheet_gid, ingest_champions_sheet must return a fully-formed
+    # counter dict (not raise, not return a partial dict) so callers
+    # can still parse the result.
+    with patch(
+        "smogon_vgc_mcp.fetcher.sheets.get_sheet_csv_url",
+        return_value=None,
+    ):
+        report = await ingest_champions_sheet(db_path=db_path)
+    assert report["auto"] == 0
+    assert report["review_pending"] == 0
+    assert report["rejected"] == 0
+    assert report["fetch_failed"] == 0
+    assert report["parse_failed"] == 0
+    assert report["db_error"] == 0
+
+
 async def test_ingest_champions_sheet_per_row_exception_isolated(db_path: Path):
     sheet_csv = "URL\nhttps://pokepast.es/a\nhttps://pokepast.es/b\n"
     call_count = {"n": 0}


### PR DESCRIPTION
## Summary

Ships the foundation for ingesting competitive Pokemon teams into a new Champions-format (Regulation M-A) data model. Handles Tier 1 (pokepaste) URLs end-to-end today; Tiers 2 (embedded Showdown) and 3 (LLM prose from X/blogs) will land in follow-up PRs per the [design spec](./docs/superpowers/specs/2026-04-22-champions-team-ingestion-design.md).

- **New data model** — parallel `champions_teams` + `champions_team_pokemon` tables using **Stat Points (SP)** instead of EVs/IVs. DB-level CHECK constraints enforce ≤32 per stat, ≤66 total, slot 1-6.
- **Deterministic validator** — 6 hard failure codes (sp_over_per_stat, sp_over_total, sp_negative, slot_count, duplicate_species, pokemon_unknown) + 6 soft codes (ability_illegal, move_illegal, item_unknown, nature_unknown, tera_type_unknown, move_count). Dex lookup injectable.
- **Normalizer** — Pokemon alias expansion, Levenshtein move fuzzy match (distance ≤2), case-fold nature/tera, item `(consumed)` strip. Every change logged for audit.
- **URL classifier** — `Tier` enum: `POKEPASTE`, `X`, `BLOG`, `UNKNOWN`. Routes URLs to the right handler.
- **Tier 1 pokepaste handler** — reuses existing `parse_pokepaste`, maps EV text → SP numerics at identity.
- **Pipeline orchestrator** — classify → fetch → normalize → validate → write-or-queue. Confidence gate (0.85 threshold) decides `auto` write vs. `review_pending`. SHA256 fingerprint dedup.
- **Sheet ingestion** — `ingest_champions_sheet()` pulls the Champions tab (`gid=791705272`) and routes each row's URL through the pipeline. Pokepaste rows auto-land, X/blog rows are rejected with `tier_not_implemented` until Phase 3+.
- **Reactive CLI** — `vgc-ingest <url>` for ad-hoc ingestion. Exit codes: 0=auto/review, 1=usage, 2=rejected, 3=fetch/parse failed.

## Architecture highlights

- Three-tier extraction model (pokepaste → embedded Showdown → LLM prose) with confidence-gated routing to either production tables or the labeler queue — low-risk teams land automatically, ambiguous ones get human review.
- Validator is pure, deterministic, and source-agnostic. Every ingested team passes the same checks regardless of where it came from.
- Parallel schema (not extending existing EV-based tables) because Champions' Stat Point system is structurally different and mixing would corrupt both.

## Scope

- ✅ Phase 1 — foundation (schema, models, validator, normalizer, queries)
- ✅ Phase 2 — Tier 1 pokepaste + sheet extension + reactive CLI
- ⏳ Phase 3 — Tier 2 embedded Showdown parsing (follow-up PR)
- ⏳ Phase 4 — Tier 3 LLM + X + blog adapters (follow-up PR)
- ⏳ Phase 5 — audit layer + MCP tool (follow-up PR)
- ⏳ Phase 6 — labeler queue integration (follow-up PR)

## Test plan

- [x] 1238 tests passing (`uv run pytest --ignore=tests/integration -q`)
- [x] Lint clean (`uv run ruff check` + `uv run ruff format --check`)
- [x] Type-check clean (`uv run ty check` on all new modules)
- [x] DB CHECK constraints verified (rejection tests for sp_over_per_stat and sp_over_total)
- [x] Pipeline end-to-end test: mocked pokepaste URL → write → read-back matches
- [x] Sheet routing test: mixed pokepaste/X/blog rows correctly categorized
- [ ] Real-world smoke: `vgc-ingest https://pokepast.es/<real-champions-team>` against a live sheet URL (defer to follow-up — the mocked pipeline test covers the code path)

## Docs

- Design spec: [\`docs/superpowers/specs/2026-04-22-champions-team-ingestion-design.md\`](./docs/superpowers/specs/2026-04-22-champions-team-ingestion-design.md)
- Implementation plan: [\`docs/superpowers/plans/2026-04-22-champions-team-ingestion-phase1-2.md\`](./docs/superpowers/plans/2026-04-22-champions-team-ingestion-phase1-2.md)

## Related

- Repo rename tracked in #17 (scope broadened beyond Smogon data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)